### PR TITLE
donwgrade pytz to v2022.1

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -7,3 +7,4 @@ isort~=5.10.1
 pytest-cov~=3.0.0
 pytest-django~=4.5.2
 pytest~=6.2.5
+pytz==2022.1


### PR DESCRIPTION
Fixes #30

- Added `pytz==2022.1` to app/requirements.txt.
- Resolves timezone errors when starting Docker container locally with latest version of base image.