### PR TITLE
encountered this issue setting up local env so adding note for future…

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -146,6 +146,18 @@ upstream        https://github.com/hackforla/peopledepot.git (push)
    ./scripts/buildrun.sh
    ```
 
+   Note: if you encounter an error regarding internal load metadata, you can run 
+   ```
+   sudo vi ~/.docker/config.json
+   ```
+   you should see a configuration such as
+   ``` 
+   {
+      "credsStore": "desktop.exe"
+   }
+   ```
+   update credsStore to credStore, save, and run the buildrun.sh script again.
+
 1. Create a super user for logging into the web admin interface
 
    ```bash


### PR DESCRIPTION
I ran into this error setting up my local environment:
ERROR [web internal] load metadata for docker.io/library/python:3.10-bullseye

I am adding a note for future users.