### PR TITLE
Create prod Dockerimage from alpine base image

### DIFF
--- a/app/prod/Dockerfile
+++ b/app/prod/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-alpine
+
+# set work directory
+WORKDIR /usr/src/app
+
+# set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# install system dependencies
+RUN apk update && \
+    apk add --no-cache netcat-openbsd gcc postgresql graphviz musl-dev libffi-dev
+
+# install dependencies
+RUN pip install --no-cache-dir pip~=21.3.1
+COPY ./requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# # copy entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]
+

--- a/app/prod/requirements.txt
+++ b/app/prod/requirements.txt
@@ -1,0 +1,14 @@
+black~=22.3.0
+cryptography~=37.0.2
+Django~=4.0.1
+django-extensions~=3.1.5
+django-linear-migrations~=2.12.0
+django-phonenumber-field[phonenumbers]~=6.3.0
+django-timezone-field==5.0
+djangorestframework~=3.13.1
+drf-jwt~=1.19.2
+drf-spectacular==0.22.1
+psycopg2-binary~=2.9.3
+pydot~=1.4.2
+pytz==2022.1
+tzdata==2022.1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:13.0-alpine
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_USER=people_depot
+      - POSTGRES_PASSWORD=people_depot
+      - POSTGRES_DB=people_depot_dev
+    container_name: people_depot_db
+  web:
+    build: ./app/prod
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - ./app/:/usr/src/app/
+    ports:
+      - 8000:8000
+    env_file:
+      - ./.env.dev
+    container_name: people_depot_app_prod
+    depends_on:
+      - db
+volumes:
+  postgres_data:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - 8000:8000
     env_file:
       - ./.env.dev
+    container_name: people_depot_dev
     depends_on:
       - db
   db:
@@ -20,6 +21,7 @@ services:
       - POSTGRES_USER=people_depot
       - POSTGRES_PASSWORD=people_depot
       - POSTGRES_DB=people_depot_dev
-
+    container_name: people_depot_db_dev
 volumes:
   postgres_data:
+


### PR DESCRIPTION
Fixes #177 

### What changes did you make?
- Added a production Docker image using alpine as base-image.

### Why did you make the changes (we will use this info to test)?
- Current Docker image is meant for development. It utilizes a larger base-image and contains dependencies unused in production.
- Reduced image size from 1.26 GB to 392.06 MB
<img width="908" alt="Screenshot 2023-10-29 at 7 29 38 PM" src="https://github.com/hackforla/peopledepot/assets/95406690/20c63d3f-f2d9-4c30-9138-37e166dac28b">

### Deploy prod environment locally
- Run following commands from` /peopledepot` root directory:

- Build production image as "alpine-pd"
`docker build -t alpine-pd -f ./app/prod/Dockerfile ./app/prod`

- Start up production services 
`docker-compose -f docker-compose.prod.yml up`
