### PR TITLE
Pre-commit CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,6 +118,11 @@ repos:
   #     - id: interrogate
   #       args: [-vv, -i, --fail-under=80]
 
+  - repo: https://github.com/mxr/sync-pre-commit-deps
+    rev: v0.0.1
+    hooks:
+      - id: sync-pre-commit-deps
+
   - repo: local
     hooks:
       - id: buildrun

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,10 @@
 # See https://pre-commit.com/hooks.html for more hooks
 default_install_hook_types: [pre-commit, pre-push]
 default_stages: [commit, push]
-fail_fast: true
 minimum_pre_commit_version: "2.18"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       # identify invalid files
       - id: check-ast
@@ -42,24 +41,24 @@ repos:
       - id: end-of-file-fixer
 
   - repo: https://github.com/AleksaC/hadolint-py
-    rev: v2.12.0
+    rev: v2.12.0.3
     hooks:
       - id: hadolint
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.15.0
     hooks:
       - id: pyupgrade
         args: [--py310-plus]
 
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1.4.0
+    rev: 1.15.0
     hooks:
       - id: django-upgrade
         args: [--target-version, "4.0"]
 
-  - repo: https://github.com/ambv/black
-    rev: 23.7.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.12.0
     hooks:
       - id: black
         exclude: ^app/core/migrations/
@@ -69,7 +68,7 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies:
-        - black==23.7.0
+        - black==23.12.0
 
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
@@ -95,14 +94,14 @@ repos:
           ]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)
         args: ["--filter-files", "--force-single-line-imports"]
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
+    rev: 1.7.6
     hooks:
       - id: bandit
         exclude: ^app/core/tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,12 @@ repos:
     hooks:
       - id: hadolint-docker
 
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.10.1
+    hooks:
+      - id: pyupgrade
+        args: [--py310-plus]
+
   - repo: https://github.com/ambv/black
     rev: 23.7.0
     hooks:
@@ -85,11 +91,6 @@ repos:
     hooks:
       - id: bandit
         exclude: ^app/core/tests/
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
-    hooks:
-      - id: pyupgrade
 
   # - repo: https://github.com/econchick/interrogate
   #   rev: 1.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,10 +41,10 @@ repos:
       - id: check-executables-have-shebangs
       - id: end-of-file-fixer
 
-  - repo: https://github.com/hadolint/hadolint
-    rev: v2.12.1-beta
+  - repo: https://github.com/AleksaC/hadolint-py
+    rev: v2.12.0
     hooks:
-      - id: hadolint-docker
+      - id: hadolint
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.10.1
@@ -107,11 +107,10 @@ repos:
       - id: bandit
         exclude: ^app/core/tests/
 
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.7.2
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.6
     hooks:
     -   id: shellcheck
-#       args: ["--severity=warning"]  # Optionally only show errors and warnings
 
   # - repo: https://github.com/econchick/interrogate
   #   rev: 1.4.0
@@ -143,3 +142,6 @@ repos:
         language: system
         types: [python] # hook only runs if a python file is staged
         pass_filenames: false
+
+ci:
+    skip: [check-django-migrations]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,11 +52,24 @@ repos:
       - id: pyupgrade
         args: [--py310-plus]
 
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: 1.4.0
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "4.0"]
+
   - repo: https://github.com/ambv/black
     rev: 23.7.0
     hooks:
       - id: black
         exclude: ^app/core/migrations/
+
+  - repo: https://github.com/asottile/blacken-docs
+    rev: 1.16.0
+    hooks:
+      - id: blacken-docs
+        additional_dependencies:
+        - black==23.7.0
 
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
@@ -77,6 +90,8 @@ repos:
             flake8-executable,
             flake8-pytest-style,
             flake8-django,
+            flake8-comprehensions,
+            flake8-tidy-imports,
           ]
 
   - repo: https://github.com/pycqa/isort
@@ -91,6 +106,12 @@ repos:
     hooks:
       - id: bandit
         exclude: ^app/core/tests/
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.7.2
+    hooks:
+    -   id: shellcheck
+#       args: ["--severity=warning"]  # Optionally only show errors and warnings
 
   # - repo: https://github.com/econchick/interrogate
   #   rev: 1.4.0

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -4,7 +4,7 @@ if [ "$DATABASE" = "postgres" ]
 then
     echo "Waiting for postgres..."
 
-    while ! nc -z $SQL_HOST $SQL_PORT; do
+    while ! nc -z "$SQL_HOST" "$SQL_PORT"; do
       sleep 0.1
     done
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,3 @@
-black~=22.3.0
 cryptography~=37.0.2
 Django~=4.0.1
 django-extensions~=3.1.5
@@ -8,8 +7,6 @@ django-timezone-field==5.0
 djangorestframework~=3.13.1
 drf-jwt~=1.19.2
 drf-spectacular==0.22.1
-flake8~=4.0.1
-isort~=5.10.1
 markdown~=3.4.1
 psycopg2-binary~=2.9.3
 pydot~=1.4.2

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -398,50 +398,6 @@ If you go to your online GitHub repository this should remove the message "This 
 
 To create a new issue, please use the blank issue template (available when you click New Issue). If you want to create an issue for other projects to use, please create the issue in your own repository and send a slack message to one of your hack night hosts with the link.
 
-## 6. Pre-commit Hooks
-
-The pre-commit hook in git is currently a work in progress.
-
-The pre-commit hook in git will run before each commit and will abort the commit on failure. The advantage of this over GitHub Actions is that GitHub Actions work on code that's already committed, so it needs to allow code to be committed first.
-
-We're setting a set of fast checks to run on each commit and longer checks such as a full rebuild to run when trying to push the code.
-
-The hooks run when doing normal `git commit` and `git push` commands. It's recommended to do this in the command line. If performing these actions from a gui application, the interface may seem to hang for some time.
-
-Installing the pre-commit hooks to git
-
-1. Install pre-commit (virtual environment or at least per-user install is recommended)
-
-   ```bash
-   pip install pre-commit --local
-   ```
-
-1. Add the hook to git
-
-   ```bash
-   pre-commit install
-   ```
-
-1. Update pre-commit and plugins to the latest version
-
-   ```bash
-   pre-commit autoupdate
-   ```
-
-1. Test run the hooks (this runs it against all files rather than only staged files)
-
-   ```bash
-   pre-commit run --all-files
-   ```
-
-1. (Extra info) More commands to test run the hooks
-
-   ```bash
-   pre-commit run --all-files --hook-stage push
-   pre-commit run --all-files --hook-stage commit
-   pre-commit run test --all-files --hook-stage push
-   ```
-
 # Appendix
 
 ## A. Submitting Bugs for Third Party Packages / Apps

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -289,13 +289,13 @@ This command will unstage a file that you don't want included in the commit. The
 git reset HEAD “filename.ext”
 ```
 
-### 4.8 Run pre-commit checks
+### 4.8 Install pre-commit
 
-**Important: before committing each file, make sure to run the pre-commit hook:\***
+This will check your changes for common problems.
 
-```bash
-./scripts/precommit-check.sh
-```
+See the [Pre-commit page](tools/pre-commit.md) for installation instructions.
+
+For consistency, an automated bot will perform the same checks on the repository side when you open a pull request.
 
 ### 4.9 Commit staged changes
 

--- a/docs/how-to/add-model-and-api-endpoints.md
+++ b/docs/how-to/add-model-and-api-endpoints.md
@@ -58,9 +58,9 @@ class RecurringEvent(AbstractBaseModel):
 1. Most fields should not be required. Text fields should be `blank=True`, data fields should be `null=True`.
 1. The data types in the github issue may be given in database column types such as `INTEGER`, `VARCHAR`, but we need to convert them into [Django field types](https://docs.djangoproject.com/en/4.1/ref/models/fields/#model-field-types) when defining the model.
 1. `VARCHAR` can be either `CharField` or `TextField`.
-   1. `CharField` has a `max_length`, which makes it useful for finite length text data. We're going default to giving them `max_length=255` unless there's a better value like `max_length=2` for state abbreviation.
-   1. `TextField` doesn't have a maximum length, which makes it ideal for large text fields such as `description`.
-1. Try to add the relationships to non-existent models, but comment them out. Another developer will complete them when they go to implement those models. See [relationships guide](model-relationships.md) for explanations of how to define relationships.
+    1. `CharField` has a `max_length`, which makes it useful for finite length text data. We're going default to giving them `max_length=255` unless there's a better value like `max_length=2` for state abbreviation.
+    1. `TextField` doesn't have a maximum length, which makes it ideal for large text fields such as `description`.
+1. Try to add the relationships to non-existent models, but comment them out. Another developer will complete them when they go to implement those models.
 1. Always override the `__str__` function to output something more meaningful than the default. It lets us do a quick test of the model by calling `str([model])`. It's also useful for the admin site model list view.
 
 ### Run migrations to generate database migration files
@@ -75,48 +75,48 @@ Since we overrode the `__str__` function, we need to write a test for it.
 
 1. Add a fixture for the model
 
-   Fixtures are reusable code that can be used in multiple tests by declaring them as parameters of the test case. In this example, we show both defining a fixture (recurring_event) and using another fixture (project).
+    Fixtures are reusable code that can be used in multiple tests by declaring them as parameters of the test case. In this example, we show both defining a fixture (recurring_event) and using another fixture (project).
 
-   Note: The conftest file is meant to hold shared test fixtures, among other things. The fixtures have directory scope.
+    Note: The conftest file is meant to hold shared test fixtures, among other things. The fixtures have directory scope.
 
-   Add the following to app/core/tests/conftest.py
+    Add the following to app/core/tests/conftest.py
 
-   ```python
-   @pytest.fixture
-   def recurring_event(project):
-       return RecurringEvent.objects.create(name="Test Recurring Event", project=project)
-   ```
+    ```python
+    @pytest.fixture
+    def recurring_event(project):
+        return RecurringEvent.objects.create(name="Test Recurring Event", project=project)
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/aad76446fc9ce3942d4f6290322ca1f73279703e/app/core/tests/conftest.py#L43-L45)
+    [link to code](https://github.com/hackforla/peopledepot/blob/aad76446fc9ce3942d4f6290322ca1f73279703e/app/core/tests/conftest.py#L43-L45)
 
-   1. We name the fixture after the model name (`recurring_event`).
-   1. This model makes use of the `project` model as a foreign key relation, so we pass in the `project` fixture, which creates a `project` model.
-   1. We create an object of the new model, passing in at least the required fields. In this case, we passed in enough arguments to use the `__str__` method in a test.
+    1. We name the fixture after the model name (`recurring_event`).
+    1. This model makes use of the `project` model as a foreign key relation, so we pass in the `project` fixture, which creates a `project` model.
+    1. We create an object of the new model, passing in at least the required fields. In this case, we passed in enough arguments to use the `__str__` method in a test.
 
 1. Add a test case
 
-   When creating Django models, there's no need to test the CRUD functionality since Django itself is well-tested and we can expect it to generate the correct CRUD functionality. Feel free to write some tests for practice. What really needs testing are any custom code that's not part of Django. Sometimes we need to override the default Django behavior and that should be tested.
+    When creating Django models, there's no need to test the CRUD functionality since Django itself is well-tested and we can expect it to generate the correct CRUD functionality. Feel free to write some tests for practice. What really needs testing are any custom code that's not part of Django. Sometimes we need to override the default Django behavior and that should be tested.
 
-   Here's a basic test to see that the model stores its name.
+    Here's a basic test to see that the model stores its name.
 
-   Add the following to app/core/tests/test_models.py
+    Add the following to app/core/tests/test_models.py
 
-   ```python
-   def test_recurring_event(recurring_event):
-       assert str(recurring_event) == "Test Recurring Event"
-   ```
+    ```python
+    def test_recurring_event(recurring_event):
+        assert str(recurring_event) == "Test Recurring Event"
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/aad76446fc9ce3942d4f6290322ca1f73279703e/app/core/tests/test_models.py#L17-L18)
+    [link to code](https://github.com/hackforla/peopledepot/blob/aad76446fc9ce3942d4f6290322ca1f73279703e/app/core/tests/test_models.py#L17-L18)
 
-   1. Pass in our fixture so that the model object is created for us.
-   1. The `__str__` method should be tested since it's an override of the default Django method.
-   1. Write assertion(s) to check that what's passed into the model is what it contains. The simplest thing to check is the `__str__` method.
+    1. Pass in our fixture so that the model object is created for us.
+    1. The `__str__` method should be tested since it's an override of the default Django method.
+    1. Write assertion(s) to check that what's passed into the model is what it contains. The simplest thing to check is the `__str__` method.
 
 1. Run the test script to show it passing
 
-   ```bash
-   ./scripts/test.sh
-   ```
+    ```bash
+    ./scripts/test.sh
+    ```
 
 ### Check point 1
 
@@ -124,16 +124,16 @@ This is a good place to pause, check, and commit progress.
 
 1. Run pre-commit checks
 
-   ```bash
-   ./scripts/precommit-check.sh
-   ```
+    ```bash
+    ./scripts/precommit-check.sh
+    ```
 
 1. Add and commit changes
 
-   ```bash
-   git add -A
-   git commit -m "feat: add model: recurring_event"
-   ```
+    ```bash
+    git add -A
+    git commit -m "feat: add model: recurring_event"
+    ```
 
 ## The admin site
 
@@ -143,30 +143,30 @@ Django comes with an admin site interface that allows admin users to view and ch
 
 1. Import the new model
 
-   ```python
-   from .models import RecurringEvent
-   ```
+    ```python
+    from .models import RecurringEvent
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/admin.py#L10)
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/admin.py#L10)
 
 1. Register the model
 
-   ```python
-   @admin.register(RecurringEvent)
-   class RecurringEventAdmin(admin.ModelAdmin):
-       list_display = (
-           "name",
-           "start_time",
-           "duration_in_min",
-       )
-   ```
+    ```python
+    @admin.register(RecurringEvent)
+    class RecurringEventAdmin(admin.ModelAdmin):
+        list_display = (
+            "name",
+            "start_time",
+            "duration_in_min",
+        )
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/admin.py#L115-L121)
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/admin.py#L115-L121)
 
-   1. We declare a [ModelAdmin](https://docs.djangoproject.com/en/4.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin) class so we can customize the fields that we expose to the admin interface.
-   1. We use the [register decorator](https://docs.djangoproject.com/en/4.0/ref/contrib/admin/#django.contrib.admin.register) to register the class with the admin site.
-   1. [list_display](https://docs.djangoproject.com/en/4.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display) controls what's shown in the list view
-   1. [list_filter](https://docs.djangoproject.com/en/4.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_filter) adds filter controls to declared fields (useful, but not shown in this example).
+    1. We declare a [ModelAdmin](https://docs.djangoproject.com/en/4.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin) class so we can customize the fields that we expose to the admin interface.
+    1. We use the [register decorator](https://docs.djangoproject.com/en/4.0/ref/contrib/admin/#django.contrib.admin.register) to register the class with the admin site.
+    1. [list_display](https://docs.djangoproject.com/en/4.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display) controls what's shown in the list view
+    1. [list_filter](https://docs.djangoproject.com/en/4.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_filter) adds filter controls to declared fields (useful, but not shown in this example).
 
 ### View the admin site to see that everything's working and there are no issues, which should be the case unless there's custom input fields creating problems
 
@@ -174,13 +174,13 @@ Django comes with an admin site interface that allows admin users to view and ch
 
 1. Example of a custom field (as opposed to the built-in ones)
 
-   ```python
-   time_zone = TimeZoneField(blank=True, use_pytz=False, default="America/Los_Angeles")
-   ```
+    ```python
+    time_zone = TimeZoneField(blank=True, use_pytz=False, default="America/Los_Angeles")
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/models.py#L96)
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/models.py#L96)
 
-   1. Having a misconfigured or buggy custom field could cause the admin site to crash and the developer will need to look at the debug message and resolve it.
+    1. Having a misconfigured or buggy custom field could cause the admin site to crash and the developer will need to look at the debug message and resolve it.
 
 ### Tests
 
@@ -194,16 +194,16 @@ This is a good place to pause, check, and commit progress.
 
 1. Run pre-commit checks
 
-   ```bash
-   ./scripts/precommit-check.sh
-   ```
+    ```bash
+    ./scripts/precommit-check.sh
+    ```
 
 1. Add and commit changes
 
-   ```bash
-   git add -A
-   git commit -m "feat: register admin: recurring_event"
-   ```
+    ```bash
+    git add -A
+    git commit -m "feat: register admin: recurring_event"
+    ```
 
 ## The API
 
@@ -215,59 +215,60 @@ This is code that serializes objects into strings for the API endpoints, and des
 
 1. Import the new model
 
-   ```python
-   from core.models import RecurringEvent
-   ```
+    ```python
+    from core.models import RecurringEvent
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/serializers.py#L6)
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/serializers.py#L6)
 
 1. Add a serializer class
 
-   ```python
-   class RecurringEventSerializer(serializers.ModelSerializer):
-       """Used to retrieve recurring_event info"""
+    ```python
+    class RecurringEventSerializer(serializers.ModelSerializer):
+        """Used to retrieve recurring_event info"""
 
-       class Meta:
-           model = RecurringEvent
-           fields = (
-               "uuid",
-               "name",
-               "start_time",
-               "duration_in_min",
-               "video_conference_url",
-               "additional_info",
-               "project",
-           )
-           read_only_fields = (
-               "uuid",
-               "created_at",
-               "updated_at",
-           )
-   ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/serializers.py#L82-L100)
+    class Meta:
+        model = RecurringEvent
+        fields = (
+            "uuid",
+            "name",
+            "start_time",
+            "duration_in_min",
+            "video_conference_url",
+            "additional_info",
+            "project",
+        )
+        read_only_fields = (
+            "uuid",
+            "created_at",
+            "updated_at",
+        )
+    ```
 
-   1. We inherit from [ModelSerializer](https://www.django-rest-framework.org/api-guide/serializers/#modelserializer). It knows how to serialize/deserialize the Django built-in data fields so we don't have to write the code to do it.
-   1. We do need to pass in the `model`, the `fields` we want to expose through the API, and any `read_only_fields`.
-   1. `uuid`, `created_at`, and `updated_at` are managed by automations and are always read-only.
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/serializers.py#L82-L100)
+
+    1. We inherit from [ModelSerializer](https://www.django-rest-framework.org/api-guide/serializers/#modelserializer). It knows how to serialize/deserialize the Django built-in data fields so we don't have to write the code to do it.
+    1. We do need to pass in the `model`, the `fields` we want to expose through the API, and any `read_only_fields`.
+    1. `uuid`, `created_at`, and `updated_at` are managed by automations and are always read-only.
 
 1. Custom data fields may need extra code in the serializer
 
-   ```python
-   time_zone = TimeZoneSerializerField(use_pytz=False)
-   ```
+    ```python
+    time_zone = TimeZoneSerializerField(use_pytz=False)
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/serializers.py#L14)
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/serializers.py#L14)
 
-   1. This non-built-in model field provides a serializer so we just point to it.
+    1. This non-built-in model field provides a serializer so we just point to it.
 
 1. Custom validators if we need them
 
-   We will need to write custom validators here if we want custom behavior, such as validating URL strings and limit them to the github user profile pattern using regular expression, for example.
+    We will need to write custom validators here if we want custom behavior, such as validating URL strings and limit them to the github user profile pattern using regular expression, for example.
 
-   ```text
-   Example here when we have one
-   ```
+    ```text
+    Example here when we have one
+    ```
 
 ### Add viewset
 
@@ -275,37 +276,37 @@ Viewset defines the set of API endpoints for the model.
 
 1. Import the serializer
 
-   ```python
-   from .serializers import RecurringEventSerializer
-   ```
+    ```python
+    from .serializers import RecurringEventSerializer
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/views.py#L14)
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/views.py#L14)
 
 1. Add the [viewset](https://www.django-rest-framework.org/api-guide/viewsets/) and CRUD API endpoint descriptions
 
-   ```python
-   @extend_schema_view(
-       list=extend_schema(description="Return a list of all the recurring events"),
-       create=extend_schema(description="Create a new recurring event"),
-       retrieve=extend_schema(description="Return the details of a recurring event"),
-       destroy=extend_schema(description="Delete a recurring event"),
-       update=extend_schema(description="Update a recurring event"),
-       partial_update=extend_schema(description="Patch a recurring event"),
-   )
-   class RecurringEventViewSet(viewsets.ModelViewSet):
-       permission_classes = [IsAuthenticated]
-       queryset = RecurringEvent.objects.all()
-       serializer_class = RecurringEventSerializer
-   ```
+    ```python
+    @extend_schema_view(
+        list=extend_schema(description="Return a list of all the recurring events"),
+        create=extend_schema(description="Create a new recurring event"),
+        retrieve=extend_schema(description="Return the details of a recurring event"),
+        destroy=extend_schema(description="Delete a recurring event"),
+        update=extend_schema(description="Update a recurring event"),
+        partial_update=extend_schema(description="Patch a recurring event"),
+    )
+    class RecurringEventViewSet(viewsets.ModelViewSet):
+        permission_classes = [IsAuthenticated]
+        queryset = RecurringEvent.objects.all()
+        serializer_class = RecurringEventSerializer
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/views.py#L112-L123)
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/views.py#L112-L123)
 
-   1. We inherit from [ModelViewSet](https://www.django-rest-framework.org/api-guide/viewsets/#modelviewset), which provides a default view implementation of all 6 CRUD actions: `create`, `retrieve`, `partial_update`, `update`, `destroy`, `list`.
-   1. We use the `extend_schema_view` decorator to attach the API doc strings to the viewset. They are usually defined as docstrings of the corresponding function definitions inside the viewset. Since we use `ModelViewSet`, there's nowhere to put the docstrings but above the viewset.
-   1. The minimum code we need with `ModelViewSet` are the `queryset`, and the `serializer_class`.
-   1. Permissions
-      1. For now use `permission_classes = [IsAuthenticated]`
-      1. It doesn't control permissions the way we want, but we will fix it later.
+    1. We inherit from [ModelViewSet](https://www.django-rest-framework.org/api-guide/viewsets/#modelviewset), which provides a default view implementation of all 6 CRUD actions: `create`, `retrieve`, `partial_update`, `update`, `destroy`, `list`.
+    1. We use the `extend_schema_view` decorator to attach the API doc strings to the viewset. They are usually defined as docstrings of the corresponding function definitions inside the viewset. Since we use `ModelViewSet`, there's nowhere to put the docstrings but above the viewset.
+    1. The minimum code we need with `ModelViewSet` are the `queryset`, and the `serializer_class`.
+    1. Permissions
+        1. For now use `permission_classes = [IsAuthenticated]`
+        1. It doesn't control permissions the way we want, but we will fix it later.
 
 ### Extended example
 
@@ -313,108 +314,110 @@ This example shows how to add a filter params. It's done for the [user model](ht
 
 1. Here's a more complex API doc example (this example is using the User model's ViewSet)
 
-   ```python
-   @extend_schema_view(
-       list=extend_schema(
-           summary="Users List",
-           description="Return a list of all the existing users",
-           parameters=[
-               OpenApiParameter(
-                   name="email",
-                   type=str,
-                   description="Filter by email address",
-                   examples=[
-                       OpenApiExample(
-                           "Example 1",
-                           summary="Demo email",
-                           description="get the demo user",
-                           value="demo-email@email.com,",
-                       ),
-                   ],
-               ),
-               OpenApiParameter(
-                   name="username",
-                   type=OpenApiTypes.STR,
-                   location=OpenApiParameter.QUERY,
-                   description="Filter by username",
-                   examples=[
-                       OpenApiExample(
-                           "Example 1",
-                           summary="Demo username",
-                           description="get the demo user",
-                           value="demo-user",
-                       ),
-                   ],
-               ),
-           ],
-       ),
-       create=extend_schema(description="Create a new user"),
-       retrieve=extend_schema(description="Return the given user"),
-       destroy=extend_schema(description="Delete the given user"),
-       update=extend_schema(description="Update the given user"),
-       partial_update=extend_schema(description="Partially update the given user"),
-   )
-   class UserViewSet(viewsets.ModelViewSet):
-   ```
+    ```python
+    @extend_schema_view(
+        list=extend_schema(
+            summary="Users List",
+            description="Return a list of all the existing users",
+            parameters=[
+                OpenApiParameter(
+                    name="email",
+                    type=str,
+                    description="Filter by email address",
+                    examples=[
+                        OpenApiExample(
+                            "Example 1",
+                            summary="Demo email",
+                            description="get the demo user",
+                            value="demo-email@email.com,",
+                        ),
+                    ],
+                ),
+                OpenApiParameter(
+                    name="username",
+                    type=OpenApiTypes.STR,
+                    location=OpenApiParameter.QUERY,
+                    description="Filter by username",
+                    examples=[
+                        OpenApiExample(
+                            "Example 1",
+                            summary="Demo username",
+                            description="get the demo user",
+                            value="demo-user",
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        create=extend_schema(description="Create a new user"),
+        retrieve=extend_schema(description="Return the given user"),
+        destroy=extend_schema(description="Delete the given user"),
+        update=extend_schema(description="Update the given user"),
+        partial_update=extend_schema(description="Partially update the given user"),
+    )
+    class UserViewSet(viewsets.ModelViewSet):
+        pass
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/views.py#L39-L79)
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/views.py#L39-L79)
 
-   1. Define strings for all 6 actions: `create`, `retrieve`, `partial_update`, `update`, `destroy`, `list`.
-   1. This one is fancy and provides examples of data to pass into the query params. It's probably more than we need right now.
-      1. The examples array can hold multiple examples.
-         1. Example ID string has to be unique but is not displayed.
-         1. `summary` string appears as an option in the dropdown.
-         1. `description` is displayed in the example.
+    1. Define strings for all 6 actions: `create`, `retrieve`, `partial_update`, `update`, `destroy`, `list`.
+    1. This one is fancy and provides examples of data to pass into the query params. It's probably more than we need right now.
+        1. The examples array can hold multiple examples.
+            1. Example ID string has to be unique but is not displayed.
+            1. `summary` string appears as an option in the dropdown.
+            1. `description` is displayed in the example.
 
 1. Add any query params according to the requirements (this example is using the User model's ViewSet)
 
-   ```python
-   class UserViewSet(viewsets.ModelViewSet):
-       ...
+    ```python
+    class UserViewSet(viewsets.ModelViewSet):
+        ...
 
-       def get_queryset(self):
-           """
-           Optionally filter users by an 'email' and/or 'username' query paramerter in the URL
-           """
-           queryset = get_user_model().objects.all()
-           email = self.request.query_params.get("email")
-           if email is not None:
-               queryset = queryset.filter(email=email)
-           username = self.request.query_params.get("username")
-           if username is not None:
-               queryset = queryset.filter(username=username)
-           return queryset
-   ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/views.py#L84-L95)
+    def get_queryset(self):
+        """
+        Optionally filter users by an 'email' and/or 'username' query paramerter in the URL
+        """
+        queryset = get_user_model().objects.all()
+        email = self.request.query_params.get("email")
+        if email is not None:
+            queryset = queryset.filter(email=email)
+        username = self.request.query_params.get("username")
+        if username is not None:
+            queryset = queryset.filter(username=username)
+        return queryset
+    ```
 
-   1. Notice the `queryset` property is now the `get_queryset(()` function which returns the queryset.
-   1. The `get_queryset()` function overrides the default and lets us filter the objects returned to the client if they pass in a query param.
-   1. Start with all the model objects and filter them based on any available query params.
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/views.py#L84-L95)
+
+    1. Notice the `queryset` property is now the `get_queryset(()` function which returns the queryset.
+    1. The `get_queryset()` function overrides the default and lets us filter the objects returned to the client if they pass in a query param.
+    1. Start with all the model objects and filter them based on any available query params.
 
 ### Register API endpoints to the router
 
 1. Import the viewset.
 
-   ```python
-   from .views import RecurringEventViewSet
-   ```
+    ```python
+    from .views import RecurringEventViewSet
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/urls.py#L6)
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/urls.py#L6)
 
 1. [Register](https://www.django-rest-framework.org/api-guide/routers/#usage) the viewset to the [router](https://www.django-rest-framework.org/api-guide/routers/)
 
-   ```python
-   router.register(r"recurring-events", RecurringEventViewSet, basename="recurring-event")
-   ```
+    ```python
+    router.register(r"recurring-events", RecurringEventViewSet, basename="recurring-event")
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/urls.py#L14)
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/api/urls.py#L14)
 
-   1. First param is the URL prefix use in the API routes. It is, by convention, plural
-      - This would show up in the URL like this: `http://localhost/api/v1/recuring-events/` and `http://localhost/api/v1/recuring-events/<uuid>`
-   1. Second param is the viewset class which defines the API actions
-   1. `basename` is the name used for generating the endpoint names, such as [basename]-list, [basename]-detail, etc. It's in the singular form. This is automatically generated if the viewset definition contains a `queryset` attribute, but it's required if the viewset overrides that with the `get_queryset` function
-      - `reverse("recurring-event-list")` would return `http://localhost/api/v1/recuring-events/`
+    1. First param is the URL prefix use in the API routes. It is, by convention, plural
+        - This would show up in the URL like this: `http://localhost/api/v1/recuring-events/` and `http://localhost/api/v1/recuring-events/<uuid>`
+    1. Second param is the viewset class which defines the API actions
+    1. `basename` is the name used for generating the endpoint names, such as [basename]-list, [basename]-detail, etc. It's in the singular form. This is automatically generated if the viewset definition contains a `queryset` attribute, but it's required if the viewset overrides that with the `get_queryset` function
+        - `reverse("recurring-event-list")` would return `http://localhost/api/v1/recuring-events/`
 
 ### Add API tests
 
@@ -422,47 +425,48 @@ For the CRUD operations, since we're using `ModelViewSet` where all the actions 
 
 1. Import API URL
 
-   ```python
-   RECURRING_EVENTS_URL = reverse("recurring-event-list")
-   ```
+    ```python
+    RECURRING_EVENTS_URL = reverse("recurring-event-list")
+    ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/tests/test_api.py#L11)
+    [link to code](https://github.com/hackforla/peopledepot/blob/09e2856b6dd8038aedbbc9b42c3a44009be1fd2f/app/core/tests/test_api.py#L11)
 
 1. Add test case
 
-   ```python
-   def test_create_recurring_event(auth_client, project):
-       """Test that we can create a recurring event"""
+    ```python
+    def test_create_recurring_event(auth_client, project):
+        """Test that we can create a recurring event"""
 
-       payload = {
-           "name": "Test Weekly team meeting",
-           "start_time": "18:00:00",
-           "duration_in_min": 60,
-           "video_conference_url": "https://zoom.com/link",
-           "additional_info": "Test description",
-           "project": project.uuid,
-       }
-       res = auth_client.post(RECURRING_EVENTS_URL, payload)
-       assert res.status_code == status.HTTP_201_CREATED
-       assert res.data["name"] == payload["name"]
-   ```
 
-   [link to code](https://github.com/hackforla/peopledepot/blob/097f8f254534c1e53bc23f14ef71afbed0b70fa0/app/core/tests/test_api.py#L150-L163)
+    payload = {
+        "name": "Test Weekly team meeting",
+        "start_time": "18:00:00",
+        "duration_in_min": 60,
+        "video_conference_url": "https://zoom.com/link",
+        "additional_info": "Test description",
+        "project": project.uuid,
+    }
+    res = auth_client.post(RECURRING_EVENTS_URL, payload)
+    assert res.status_code == status.HTTP_201_CREATED
+    assert res.data["name"] == payload["name"]
+    ```
 
-   1. Given
-      1. Pass in the necessary fixtures
-      1. Construct the payload
-   1. When
-      1. Create the object
-   1. Then
-      1. Check that it's created via [status code](https://www.django-rest-framework.org/api-guide/status-codes/#client-error-4xx)
-      1. Maybe also check the data. A real test should check all the data, but we're kind of relying on django to have already tested this.
+    [link to code](https://github.com/hackforla/peopledepot/blob/097f8f254534c1e53bc23f14ef71afbed0b70fa0/app/core/tests/test_api.py#L150-L163)
+
+    1. Given
+        1. Pass in the necessary fixtures
+        1. Construct the payload
+    1. When
+        1. Create the object
+    1. Then
+        1. Check that it's created via [status code](https://www.django-rest-framework.org/api-guide/status-codes/#client-error-4xx)
+        1. Maybe also check the data. A real test should check all the data, but we're kind of relying on django to have already tested this.
 
 1. Run the test script to show it passing
 
-   ```bash
-   ./scripts/test.sh
-   ```
+    ```bash
+    ./scripts/test.sh
+    ```
 
 ### Check point 3
 
@@ -470,16 +474,16 @@ This is a good place to pause, check, and commit progress.
 
 1. Run pre-commit checks
 
-   ```bash
-   ./scripts/precommit-check.sh
-   ```
+    ```bash
+    ./scripts/precommit-check.sh
+    ```
 
 1. Add and commit changes
 
-   ```bash
-   git add -A
-   git commit -m "feat: add endpoints: recurring_event"
-   ```
+    ```bash
+    git add -A
+    git commit -m "feat: add endpoints: recurring_event"
+    ```
 
 ### Push the code and start a PR
 

--- a/docs/tools/pre-commit.md
+++ b/docs/tools/pre-commit.md
@@ -1,17 +1,19 @@
 # Pre-commit
 
-The pre-commit hook in git will run before each commit and will abort the commit on failure. The advantage of this over GitHub Actions is that GitHub Actions work on code that's already committed, so it needs to allow code to be committed first.
+The hooks will run when doing normal `git commit` and `git push` commands. It's recommended to do this in the command line to see the output. If performing these actions from a gui application, the interface may seem to hang for some time.
 
-We're setting a set of fast checks to run on each commit and longer checks such as a full rebuild to run when trying to push the code.
+The pre-commit checks should be fast while the pre-push hooks will take longer since they'll do a full rebuild
 
-The hooks run when doing normal `git commit` and `git push` commands. It's recommended to do this in the command line. If performing these actions from a gui application, the interface may seem to hang for some time.
+## Installation
 
-Installing the pre-commit hooks to git
+It's recommended to install "global" tools via pipx, which installs packages in an isolated environment rather than the global python environment.
 
-1. Install pre-commit (virtual environment or at least per-user install is recommended)
+1. [Install pipx](https://pipx.pypa.io/latest/installation/)
+
+1. Install pre-commit
 
    ```bash
-   pip install pre-commit --local
+   pipx install pre-commit
    ```
 
 1. Add the hook to git
@@ -20,22 +22,46 @@ Installing the pre-commit hooks to git
    pre-commit install
    ```
 
-1. Update pre-commit and plugins to the latest version
+   Pre-commit is now set up to check your files whenever you commit or push code.
 
-   ```bash
-   pre-commit autoupdate
-   ```
+1. Test by adding an empty commit
 
-1. Test run the hooks (this runs it against all files rather than only staged files)
+    ```bash
+    git commit --allow-empty -m "Test"
+    ```
+
+    You should see a list of tests that are all skipped, because there's no changes in the commit to test.
+
+## Extra information
+
+- To skip the checks temporarily, you can do one of these
+
+    '''bash
+    # skip all the hooks
+    git commit --no-verify
+    # skip specific hooks
+    SKIP=black,flake8 git commit
+    '''
+
+- Manually run the hooks (this runs it against all files rather than only changed files)
 
    ```bash
    pre-commit run --all-files
    ```
 
-1. (Extra info) More commands to test run the hooks
+- More commands to run the hooks
 
    ```bash
+   # run the hooks for the push staga
    pre-commit run --all-files --hook-stage push
+   # run the hooks for the commit stage
    pre-commit run --all-files --hook-stage commit
+   # run the hooks for
    pre-commit run test --all-files --hook-stage push
+   ```
+
+- Update pre-commit and plugins to the latest version
+
+   ```bash
+   pre-commit autoupdate
    ```

--- a/docs/tools/pre-commit.md
+++ b/docs/tools/pre-commit.md
@@ -1,0 +1,41 @@
+# Pre-commit
+
+The pre-commit hook in git will run before each commit and will abort the commit on failure. The advantage of this over GitHub Actions is that GitHub Actions work on code that's already committed, so it needs to allow code to be committed first.
+
+We're setting a set of fast checks to run on each commit and longer checks such as a full rebuild to run when trying to push the code.
+
+The hooks run when doing normal `git commit` and `git push` commands. It's recommended to do this in the command line. If performing these actions from a gui application, the interface may seem to hang for some time.
+
+Installing the pre-commit hooks to git
+
+1. Install pre-commit (virtual environment or at least per-user install is recommended)
+
+   ```bash
+   pip install pre-commit --local
+   ```
+
+1. Add the hook to git
+
+   ```bash
+   pre-commit install
+   ```
+
+1. Update pre-commit and plugins to the latest version
+
+   ```bash
+   pre-commit autoupdate
+   ```
+
+1. Test run the hooks (this runs it against all files rather than only staged files)
+
+   ```bash
+   pre-commit run --all-files
+   ```
+
+1. (Extra info) More commands to test run the hooks
+
+   ```bash
+   pre-commit run --all-files --hook-stage push
+   pre-commit run --all-files --hook-stage commit
+   pre-commit run test --all-files --hook-stage push
+   ```

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -3,18 +3,6 @@ set -euo pipefail
 IFS=$'\n\t'
 set -x
 
-# run linters and code formatters
-
-# https://github.com/hadolint/hadolint
-# hadolint app/Dockerfile
-docker run --rm -i hadolint/hadolint < app/Dockerfile
-
-docker-compose exec -T web black --exclude=migrations .
-
-# docker-compose exec -T web black --check --exclude=migrations .
-# docker-compose exec -T web black --diff --exclude=migrations .
-docker-compose exec -T web flake8 .
-
-docker-compose exec -T web isort . --force-single-line-imports
+pre-commit run --all-files --show-diff-on-failure
 
 docker-compose exec -T web python manage.py spectacular --file /tmp/schema.yaml --validate

--- a/scripts/precommit-check.sh
+++ b/scripts/precommit-check.sh
@@ -8,5 +8,3 @@ set -x
 "$SCRIPT_DIR"/buildrun.sh
 "$SCRIPT_DIR"/lint.sh
 "$SCRIPT_DIR"/test.sh
-
-pre-commit run --all-files


### PR DESCRIPTION
- Fixes #124

### What changes did you make?

- adapted pre-commit config for ci
- updated pre-commit config
- updated and extended documentation for pre-commit
- formatted documentation touched by pre-commit checks
- removed local linters and fomatters

### Why did you make the changes (we will use this info to test)?

- We're using pre-commit for linting and formatting, so there's no need to also install the packages locally. Pre-commit manages its own environment that's separate from the project.
- I had to switch some pre-commit hooks to ones that will also download the tools rather than rely on them being present in the local system, since they won't be available in the ci environment.
- Some hooks are just outdated so I updated them.
- There's a few new hooks that I thought were good to add.
- I updated the documentation both to fix formatting and with content for the current changes.

### Before and After

I created test PRs to show the CI service at work.
[Before](https://github.com/fyliu/peopledepot/pull/15): this branch adds a squashed commit of the changes made in [initial-data-migration-36](https://github.com/hackforla/peopledepot/tree/initial-data-migration-36). It has some linting problems that need fixing.

[After](https://github.com/fyliu/peopledepot/pull/16): this is after fixing the linter issues. It is one more commit on top of the Before branch.

### How to test

You will have to connect to the pre-commit.ci service in your fork in order for this to work in your fork. Just create PRs from the branches in my fork (or anywhere) to see it working.

I haven't connected it to the hackforla repo yet since the current pre-commit config we have doesn't quite work for ci.