### PR TITLE
Add mdformat to pre-commit

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-project-logo-or-image-to-your-main-repository.md
+++ b/.github/ISSUE_TEMPLATE/add-project-logo-or-image-to-your-main-repository.md
@@ -4,15 +4,17 @@ about: Simple action that will make it possible to add project to hackforla.org 
 title: ''
 labels: enhancement
 assignees: ''
-
 ---
 
 ### Overview
+
 By adding the project's logo/image to your project's primary repository, we will be able to dynamically deliver up to date information about your project to the hackforla.org website.  Also when people add the link to the repository in LinkedIn or Slack, or other social media it will automatically use the image as well as the description, improving the link's chances of getting clicked on.
 
 ### Action Items
+
 Add project's logo/image to your primary Github repository using the instructions below.  You should use the same image as is on the hackforla.org website, or if another image is desired, please replace both with the same image.
 
 ### Resources/Instructions
+
 Tip: Your image should be a PNG, JPG, or GIF file under 1 MB in size. For the best quality rendering, we recommend keeping the image at 640 by 320 pixels.
 Read Github's [Customizing your repository's social media preview](https://help.github.com/en/articles/customizing-your-repositorys-social-media-preview)

--- a/.github/ISSUE_TEMPLATE/blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue.md
@@ -4,20 +4,26 @@ about: Consistent formatting makes Issues concise and easy to navigate.
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 ### Overview
+
 Briefly describe the purpose of this issue.
+
 <!-- Clearly states the purpose of this issue in 2 sentences or less. -->
 
 ### Action Items
+
 If this is a new issue, describe what research and documentation are likely needed.
+
 <!-- If this is the beginning of the task this is most likely something to be researched and documented. -->
 
 If this is an existing issue, describe the steps and course of actions. If this is a complex issue, maybe it'd be helpful to divide into separate issues.
+
 <!-- If the issue has already been researched, and the course of action is clear, this will describe the steps. However, if the steps can be divided into tasks for more than one person, we recommend dividing it up into separate issues, or assigning it as a pair programming task. -->
 
 ### Resources/Instructions
+
 Documentation or websites that can be helpful.
+
 <!-- If there is a website which has documentation that helps with this issue provide the link(s) here. -->

--- a/.github/ISSUE_TEMPLATE/control-what-appears-when-you-paste-your-sites-link-in-social-media-sites.md
+++ b/.github/ISSUE_TEMPLATE/control-what-appears-when-you-paste-your-sites-link-in-social-media-sites.md
@@ -4,13 +4,14 @@ about: Add Open Graph Markup tags to header
 title: Control what appears when you paste your sites link in social media sites
 labels: enhancement, question
 assignees: ''
-
 ---
 
 ### Overview
+
 When your website is shared on slack, facebook, twitter, etc. It should automatically display with an image and title instead of just the URL.
 
 ### Action items
+
 Identify what to put in the following fields:
 og:url
 g:type
@@ -24,4 +25,5 @@ using the standards set forth in the instructions.
 Add content to header and test with the tool provided in the instructions.
 
 ### Instructions
+
 [A Guide to Sharing for Webmasters](https://developers.facebook.com/docs/sharing/webmasters#markup)

--- a/.github/ISSUE_TEMPLATE/create-agenda.md
+++ b/.github/ISSUE_TEMPLATE/create-agenda.md
@@ -4,11 +4,12 @@ about: Assign issue to all team members day after meetup in prep for next meetup
 title: ''
 labels: documentation, help wanted, question
 assignees: ''
-
 ---
 
 ### Overview
+
 Gather all items team members want to propose for this weeks' agenda.
 
 ### Action Items
+
 Add comment to this issue with your proposed agenda item. if item warrants an issue of its own please start a new issue, by going to the issues tab above and clicking on the New Issues green button.

--- a/.github/ISSUE_TEMPLATE/create-project-card-for--project-name-.md
+++ b/.github/ISSUE_TEMPLATE/create-project-card-for--project-name-.md
@@ -4,27 +4,29 @@ about: Gather information to add this project to HackforLA's website
 title: ''
 labels: documentation, good first issue, question
 assignees: ''
-
 ---
 
 ### Overview
+
 Provide collateral for the HackforLA website
 
 ### Action Items
-- [ ]   Gather items
-  - [ ]  600 x 400 image
-     - [ ]  Alt image text
-  - [ ] 1500 x 700 hero image (please do not put project title on hero image)
-     - [ ]  Alt image text
-  - [ ]  Name of project
-  - [ ]  A blurb about your project
-  - [ ]  Links (github, slack channel url, Testing Site, Live Site, etc.)
-  - [ ]  Any resources for a Getting Started link (a link to a wiki, readme(s) or both)
-  - [ ]  What you are looking for skills wise
-  - [ ]  Partner(s)
-  - [ ]  Location
-  - [ ]  Status
-- [ ]   Add project Card to website
+
+- [ ] Gather items
+    - [ ] 600 x 400 image
+        - [ ] Alt image text
+    - [ ] 1500 x 700 hero image (please do not put project title on hero image)
+        - [ ] Alt image text
+    - [ ] Name of project
+    - [ ] A blurb about your project
+    - [ ] Links (github, slack channel url, Testing Site, Live Site, etc.)
+    - [ ] Any resources for a Getting Started link (a link to a wiki, readme(s) or both)
+    - [ ] What you are looking for skills wise
+    - [ ] Partner(s)
+    - [ ] Location
+    - [ ] Status
+- [ ] Add project Card to website
 
 ### Resources/Instructions
+
 See project cards on the hackforla.org website for examples

--- a/.github/ISSUE_TEMPLATE/create-table-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/create-table-issue-template.md
@@ -4,18 +4,20 @@ about: Create an issue for each table required
 title: 'Create Table: [name of table]'
 labels: 'role: back end, size: 2pt'
 assignees: ''
-
 ---
 
 ### Overview
-We need to create the [name of table] table so that we can update a shared data store across hackforla.org, vrms, civictechjobs, and tables (onboarding) project.
+
+We need to create the \[name of table\] table so that we can update a shared data store across hackforla.org, vrms, civictechjobs, and tables (onboarding) project.
 
 #### Details
+
 A table and a model are the same thing
 
 ### Action Items
+
 - [ ] identify if table has a description (see spreadsheet under Resources)
-  - [ ] if not, reach out to PD leads
+    - [ ] if not, reach out to PD leads
 - [ ] identify and document  (below) what other tables are associated (see ERD under Resources)
 - [ ] create a single model in Django (defining schema)
 - [ ] Write a test for the relationships this model will have with other models (e.g., creating a user and assigning them a set of permissions on a project).
@@ -24,14 +26,19 @@ A table and a model are the same thing
 - [ ] Document the endpoint in Swagger
 
 ### Resources/Instructions
+
 - See [People Depot Resources wiki page](https://github.com/hackforla/peopledepot/wiki/Resources-and-Links) for links
 
 ### Items to document (referenced above)
+
 #### Description
+
 -
 
 #### Associated Tables
+
 -
 
 #### Swagger Endpoint Link
+
 -

--- a/.github/ISSUE_TEMPLATE/emergent-request.md
+++ b/.github/ISSUE_TEMPLATE/emergent-request.md
@@ -1,38 +1,36 @@
 ---
 name: Emergent Request
-about: When you discover something in your issue that is out of scope and it needs
-  a new issue or discussion
+about: When you discover something in your issue that is out of scope and it needs a new issue or discussion
 title: 'ER: [replace with info ]'
 labels: 'size: 0.25pt'
 assignees: ''
-
 ---
 
 ### Emergent Requirement - Problem
 
-
 ### Issue you discovered this emergent requirement in
+
 - #
 
 ### Date discovered
 
-
 ### Did you have to do something temporarily
+
 - [ ] YES
 - [ ] NO
 
 ### Who was involved
+
 @
 
 ### What happens if this is not addressed
 
-
 ### Resources
 
-
 ### Recommended Action Items
+
 - [ ] Make a new issue
 - [ ] Discuss with team
 - [ ] Let a Team Lead know
 
-### Potential solutions [draft]
+### Potential solutions \[draft\]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,29 +4,30 @@ about: Suggest an idea for this project
 title: 'Feature Suggestion: '
 labels: documentation
 assignees: ''
-
 ---
 
 ### Overview
-Please write a user story for this feature suggestion in the following format: As a ______, I want to do X for Y reason and replace this text with it.
+
+Please write a user story for this feature suggestion in the following format: As a \_\_\_\_\_\_, I want to do X for Y reason and replace this text with it.
 
 ### Action Items
+
 - [ ] Define your Feature Suggestion
-   - [ ] What is the feature you are suggesting?
-   - [ ] Is this feature urgent
-      - [ ] if so why?
-   - [ ] How long do you expect it take to implement this issue?
-   - [ ] Who is needed to implement this feature (Could you implement it yourself?)
-      - [ ] Design
-      - [ ] Front End
-      - [ ] Back End
-      - [ ] Database
-   - [ ] What problem does this feature solve?
-   - [ ] What technologies are needed for this feature?
+    - [ ] What is the feature you are suggesting?
+    - [ ] Is this feature urgent
+        - [ ] if so why?
+    - [ ] How long do you expect it take to implement this issue?
+    - [ ] Who is needed to implement this feature (Could you implement it yourself?)
+        - [ ] Design
+        - [ ] Front End
+        - [ ] Back End
+        - [ ] Database
+    - [ ] What problem does this feature solve?
+    - [ ] What technologies are needed for this feature?
 
 ### Resources/Instructions
-If there is a website which has documentation that helps with this issue provide the link(s) here:
 
+If there is a website which has documentation that helps with this issue provide the link(s) here:
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/lighthouse--accessibility---forms.md
+++ b/.github/ISSUE_TEMPLATE/lighthouse--accessibility---forms.md
@@ -1,20 +1,21 @@
 ---
 name: 'Lighthouse: Accessibility - Forms'
-about: Instructions for creating or improving forms to make them accessible when visitors
-  use screen readers   AKA Form <input> elements must have labels
+about: Instructions for creating or improving forms to make them accessible when visitors use screen readers   AKA Form <input> elements must have labels
 title: 'Lighthouse: Accessibility - Forms'
 labels: ''
 assignees: ''
-
 ---
 
 ### Overview
+
 In order for your sites form(s) to be usable by visitors using screen readers all the form <input> elements need labels.  There are specific details and exceptions, which can be found in the instructions below.
 
 ### Action Items
+
 *If your site already has forms* review the instructions and document the changes needed to bring your form(s) into WCAG compliance, by commenting on this issue.
 *If your site does not have forms* review the instructions and design new forms using the WCAG standards.
 
 ### Instructions
+
 Deque University
 https://dequeuniversity.com/rules/axe/3.2/label

--- a/.github/ISSUE_TEMPLATE/lighthouse--accessibility---links.md
+++ b/.github/ISSUE_TEMPLATE/lighthouse--accessibility---links.md
@@ -4,16 +4,18 @@ about: AKA Links must have discernible text
 title: 'Lighthouse: Accessibility - Links'
 labels: ''
 assignees: ''
-
 ---
 
 ### Overview
+
 The formatting of links can make them readable or unreadable by screen readers.  Which includes creating programmatic events for links without making them device specific (e.g., onfocus() instead of onmouseover(), etc.), and other ways of making sure all links are visible by screen readers.
 
 ### Action Items
+
 *If your site already has links* review the instructions and document the changes needed to bring your link(s) into WCAG compliance, by commenting on this issue.
 *If your site does not have links yet* review the instructions and design all new links using the WCAG standards.
 
 ### Instructions
+
 Deque University
 https://dequeuniversity.com/rules/axe/3.2/link-name

--- a/.github/ISSUE_TEMPLATE/lighthouse--cross-origin-destinations-are-unsafe.md
+++ b/.github/ISSUE_TEMPLATE/lighthouse--cross-origin-destinations-are-unsafe.md
@@ -4,15 +4,16 @@ about: Instructions for addressing the cross-origin linking vulnerabilities
 title: 'Lighthouse Issue: Cross-origin destinations are unsafe'
 labels: ''
 assignees: ''
-
 ---
 
 ### Overview
+
 Links to cross-origin destinations are unsafe both from a security and performance perspective.
 
 ### Action Item
-Run [Lighthouse](https://developers.google.com/web/tools/lighthouse/) and then follow the instructions in [cross-origin destinations are unsafe]
-(https://developers.google.com/web/tools/lighthouse/audits/noopener) .
+
+Run [Lighthouse](https://developers.google.com/web/tools/lighthouse/) and then follow the instructions in [cross-origin destinations are unsafe](https://developers.google.com/web/tools/lighthouse/audits/noopener).
 
 ## Summary of instructions
-When using *target=_blank* also adding *rel="noopener"* to the tag ensures that new page runs in a separate process.
+
+When using *target=\_blank* also adding *rel="noopener"* to the tag ensures that new page runs in a separate process.

--- a/.github/ISSUE_TEMPLATE/lighthouse--how-to.md
+++ b/.github/ISSUE_TEMPLATE/lighthouse--how-to.md
@@ -4,24 +4,26 @@ about: Provides overview of how to use Lighthouse and links to additional resour
 title: 'Lighthouse: How To'
 labels: ''
 assignees: ''
-
 ---
 
 ### Overview
+
 Lighthouse is an open-source, automated tool for improving the quality of web pages. You can run it against any web page, public or requiring authentication. It has audits for performance, accessibility, progressive web apps, and more.  Hack For LA recommends that you run the tests and evaluate what changes you might want to make on your website to improve performance and accessability.
 
 ### How To Use
+
 Lighthouse is in the Audits panel of the Chrome DevTools. To run a report:
 
 1. Download Google Chrome for Desktop.
-2. In Google Chrome, go to the URL you want to audit. You can audit any URL on the web.
-3. Open Chrome DevTools.
-4. Click the Audits tab.
-5. Click Perform an audit. DevTools shows you a list of audit categories. Leave them all enabled.
-6. Click Run audit. After 60 to 90 seconds, Lighthouse gives you a report on the page.
+1. In Google Chrome, go to the URL you want to audit. You can audit any URL on the web.
+1. Open Chrome DevTools.
+1. Click the Audits tab.
+1. Click Perform an audit. DevTools shows you a list of audit categories. Leave them all enabled.
+1. Click Run audit. After 60 to 90 seconds, Lighthouse gives you a report on the page.
 
 For more information go to :
 https://developers.google.com/web/tools/lighthouse/
 
 ### Tip
+
 You will want to re-run lighthouse on any code changes before integrating them into your site.  Sometimes the specific suggestions it makes, do not actually result in improved performance or can actually harm performance.

--- a/.github/ISSUE_TEMPLATE/lighthouse--image-optimization.md
+++ b/.github/ISSUE_TEMPLATE/lighthouse--image-optimization.md
@@ -4,15 +4,17 @@ about: Instructions for optimizing images
 title: 'Lighthouse: Image Optimization'
 labels: ''
 assignees: ''
-
 ---
 
 ### Overview
+
 When you run the lighthouse review it may suggest some specific image optimizations such as choosing another image format and making those changes may or may not improve your sites actual performance.
 
 ### Action Items
+
 Run lighthouse on a local version of the website and then apply suggested changes and retest locally before determining if you want to keep the changes.
 
 ### Instructions/Resources
+
 Google's Tools for Web Developers: [Optimize Images](https://developers.google.com/web/tools/lighthouse/audits/optimize-images)
 Read [closed issue #111](https://github.com/hackforla/website/issues/111) from when HackforLA.org did our audit, to see why we decided not to do the image optimization

--- a/.github/ISSUE_TEMPLATE/proposal-to-change-project-md-file-format.md
+++ b/.github/ISSUE_TEMPLATE/proposal-to-change-project-md-file-format.md
@@ -4,26 +4,32 @@ about: To propose changes to project.md file format
 title: Proposal to change project.md file format [that accomplishes x]
 labels: documentation, enhancement
 assignees: ''
-
 ---
 
 ### Overview
+
 Describe the purpose for the proposal change
 
 ### Action items
+
 - [ ] Indicate current state in a yaml snipit here:
 
 - [ ] Indicate desired future state in a yaml snipit here:
 
 - [ ] Perform test
-   - [ ] one project.md file
-   - [ ] updating logic of appropriate include file
-   - [ ] Get signoff
+
+    - [ ] one project.md file
+    - [ ] updating logic of appropriate include file
+    - [ ] Get signoff
+
 - [ ] update all project.md files with new or revised fields
+
 - [ ] Update Template project.md wiki page
-- [ ] Submit pull request - indicating Issue #294 is affected (format changes log), and the text "fixes Issue #[number that you are creating now]
+
+- [ ] Submit pull request - indicating Issue #294 is affected (format changes log), and the text "fixes Issue #\[number that you are creating now\]
 
 ### Resources
+
 Wiki page - [Template of a project.md file](https://github.com/hackforla/website/wiki/Template-of-a-project.md-file)
 
 ***Links to comments on other issues where this proposal originated***

--- a/.github/ISSUE_TEMPLATE/update-content-for-readme-file.md
+++ b/.github/ISSUE_TEMPLATE/update-content-for-readme-file.md
@@ -4,17 +4,19 @@ about: Instructions for revising the README.md file inside this repository
 title: ''
 labels: documentation, good first issue, help wanted, question
 assignees: ''
-
 ---
 
 ### Overview
+
 We need to have a working READme file to easily on-board new team members.
 
 ### Action Items
+
 - [ ] Add the following information as a comment to this issue:
-   - [ ] Identify what information needs to be collected.
-   - [ ] Identify who holds each piece of information.
-   - [ ] Collect information.
+    - [ ] Identify what information needs to be collected.
+    - [ ] Identify who holds each piece of information.
+    - [ ] Collect information.
 
 ### Resources/Instructions
+
 PUT LINK TO README.md FILE HERE

--- a/.github/ISSUE_TEMPLATE/update-project-profile---name-of-project-.md
+++ b/.github/ISSUE_TEMPLATE/update-project-profile---name-of-project-.md
@@ -1,17 +1,17 @@
 ---
 name: 'Update Project Profile: [name of project]'
-about: We are making a project home page for each project and need some additional
-  info
+about: We are making a project home page for each project and need some additional info
 title: 'Update Project Profile: [name of project]'
 labels: documentation
 assignees: ''
-
 ---
 
 ### Overview
+
 Update the following fields for your project. These updated fields will then be updated to be shown on the website.
 
 ### Action Items
+
 - [ ] Update wording of anything currently on the project card (see [hackforla.org](https://www.hackforla.org/))
 - [ ] Provide information on which Tools your team is using for the project (Ex: figma, Balsamiq, photoshop, etc.) . This is different than programming languages
 - [ ] Update "Looking For" Section
@@ -20,4 +20,5 @@ Update the following fields for your project. These updated fields will then be 
 - [ ] Any resources for a Getting Started link (either a link to a wiki or readme)
 
 ### Resources/Instructions
+
 See the hero image on the [hackforla.org](https://www.hackforla.org/) homepage

--- a/.github/ISSUE_TEMPLATE/update-team-roster.md
+++ b/.github/ISSUE_TEMPLATE/update-team-roster.md
@@ -4,14 +4,16 @@ about: Provides new team members a link to team roster to input their informatio
 title: ''
 labels: documentation, good first issue, question
 assignees: ''
-
 ---
 
 ### Overview
+
 Rolling Roster of Team Participants.
 
 ### Action Items
+
 Add or update your personal info to the team roster.
 
 ### Resources/Instructions
+
 ADD URL TO TEAM ROSTER HERE

--- a/.github/ISSUE_TEMPLATE/wave-chrome-extension--accessibility-review.md
+++ b/.github/ISSUE_TEMPLATE/wave-chrome-extension--accessibility-review.md
@@ -4,14 +4,14 @@ about: Describe this issue template's purpose here.
 title: 'Wave Chrome Extension: Accessibility review'
 labels: ''
 assignees: ''
-
 ---
 
 ### Overview
 
 #### Action Items
+
 1. add [WAVE chrome extension](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
-2. visit site
-3. click the extension and review the red flags.
-4. Run the same steps for the development site (localhost). Ensure that the chrome extension has the "Allow access to file URLs" enabled.
-5. Document all suggested changes in the comments.
+1. visit site
+1. click the extension and review the red flags.
+1. Run the same steps for the development site (localhost). Ensure that the chrome extension has the "Allow access to file URLs" enabled.
+1. Document all suggested changes in the comments.

--- a/.github/ISSUE_TEMPLATE/which-accessibility-testing-tool-should-you-use-.md
+++ b/.github/ISSUE_TEMPLATE/which-accessibility-testing-tool-should-you-use-.md
@@ -1,17 +1,17 @@
 ---
 name: Which accessibility testing tool should you use?
-about: There are a lot of tools, this issue has a list of our favorites and links
-  to more
+about: There are a lot of tools, this issue has a list of our favorites and links to more
 title: Which accessibility testing tool should you use?
 labels: ''
 assignees: ''
-
 ---
 
 ### Overview
+
 There are more than 100 accessibility testing tools.  Figuring out which ones to use can be a black hole.  For guidance we recommend this article:  [Which accessibility testing tool should you use?](https://medium.com/pulsar/which-accessibility-testing-tool-should-you-use-e5990e6ef0a)
 
 ### Summary of Article
+
 The author recommends using the tools in the following order fixing as you go along, since no one tool catches all the relevant issues
 
 [aXe](https://www.deque.com/axe/)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,7 +140,6 @@ repos:
       - id: mdformat
         exclude: |
           (?x)^(
-            .github/ISSUE_TEMPLATE/|
             docs/CONTRIBUTING.md$|
             docs/index.md$|
             docs/license.md$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,6 +134,21 @@ repos:
       - id: ruff-format
         exclude: ^app/core/migrations/
 
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.17
+    hooks:
+      - id: mdformat
+        exclude: |
+          (?x)^(
+            .github/ISSUE_TEMPLATE/|
+            docs/CONTRIBUTING.md$|
+            docs/index.md$|
+            docs/license.md$
+          )
+        additional_dependencies:
+          - mdformat-admon
+          - mdformat-mkdocs[recommended]>=2.0.0
+
   - repo: local
     hooks:
       - id: buildrun


### PR DESCRIPTION
Fixes #232

### What changes did you make?

- Added mdformat to autoformat markdown documentation files
- Autoformatted ISSUE_TEMPLATE markdown files and manually checked that they're right

### Why did you make the changes (we will use this info to test)?

- Having a formatter will make markdown file structure more standardized so that contributors can focus more on the contents
- I set it to reformat md files as much as possible to set a good baseline

### How to test

Either add some markdown or break something existing.
There's no point running `pre-commit run --all-files` since the pre-commit.io bot already ran it.