### PR TITLE
Fix missing mkdocs plugin for awesome pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,5 +22,6 @@ jobs:
             mkdocs-material-
       - run: pip install \
           mkdocs-material==9.1.17 \
+          mkdocs-awesome-pages-plugin==2.9.1 \
           mkdocs-autolinks-plugin==0.7.1
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
Fixes #237

### What changes did you make?

- added awesome-pages plugin to gha

### Why did you make the changes (we will use this info to test)?

- it fixes the issue and allows the docs to generate successfully

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->

<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals (in hackforla repo) before changes are applied</summary>

![2024-01-17 20 34 49 github com 91c74a573d88](https://github.com/hackforla/peopledepot/assets/1160105/140fa24a-31e1-4b7f-8046-1fc09eb46da8)

</details>

<details>
<summary>Visuals (in my fork) after changes are applied</summary>

![2024-01-17 20 35 41 github com 74fc9b463ad0](https://github.com/hackforla/peopledepot/assets/1160105/cbeeacc5-4ea1-4d36-bdcc-f17fb2d6bd6b)

</details>
