### PR TITLE
Fix hooks in macOS 247

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,6 @@ repos:
             flake8-bugbear,
             dlint,
             flake8-use-fstring,
-            flake8-use-pathlib,
             flake8-builtins,
             pep8-naming,
             flake8-variables-names,
@@ -101,7 +100,7 @@ repos:
         args: ["--filter-files", "--force-single-line-imports"]
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.6
+    rev: 1.7.7
     hooks:
       - id: bandit
         exclude: ^app/core/tests/
@@ -122,6 +121,18 @@ repos:
   #   rev: v0.0.1
   #   hooks:
   #     - id: sync-pre-commit-deps
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.14
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+        exclude: ^app/core/migrations/
+      # Run the formatter.
+      - id: ruff-format
+        exclude: ^app/core/migrations/
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,10 +117,11 @@ repos:
   #     - id: interrogate
   #       args: [-vv, -i, --fail-under=80]
 
-  - repo: https://github.com/mxr/sync-pre-commit-deps
-    rev: v0.0.1
-    hooks:
-      - id: sync-pre-commit-deps
+  # disabled because it reformats this yaml file
+  # - repo: https://github.com/mxr/sync-pre-commit-deps
+  #   rev: v0.0.1
+  #   hooks:
+  #     - id: sync-pre-commit-deps
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
         args: [--target-version, "4.0"]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.0
+    rev: 23.12.1
     hooks:
       - id: black
         exclude: ^app/core/migrations/
@@ -68,10 +68,10 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies:
-        - black==23.12.0
+        - black==23.12.1
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         exclude: ^app/core/migrations/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff.lint]
+select = [ "PTH" ]


### PR DESCRIPTION
- Fixes #247

### What changes did you make?

- disabled flake8-use-pathlib
- setup ruff and enabled PTH checks
- disabled sync-pre-commit-deps

### Why did you make the changes (we will use this info to test)?

- PTH in ruff is equivalent to flake8-use-pathlib
- sync-pre-commit-deps does unwanted reformatting of the yaml file

### How to test
change this line in `app/peopledepot/settings.py` from

```
"NAME": os.environ.get("SQL_DATABASE", BASE_DIR / "db.sqlite3"),
```
to
```
"NAME": os.environ.get("SQL_DATABASE", os.path.join(BASE_DIR, "db.sqlite3")),
```
and run `pre-commit run --all-files`, and it should complain about the rule.
```
ruff.....................................................................Failed
- hook id: ruff
- exit code: 1

app/peopledepot/settings.py:121:48: PTH118 `os.path.join()` should be replaced by `Path` with `/` operator
Found 1 error.
```
