### PR TITLE
Eliminate external JSON export script

### DIFF
--- a/app/scripts/convert.py
+++ b/app/scripts/convert.py
@@ -1,13 +1,14 @@
-# converts an spreadsheet-exported json into one that can be used in a django
+# converts an csv spreadsheet into one that can be used in a django
 # migration
 
 # example:
 # docker-compose exec web python core/scripts/convert.py \
-# core/initial_data/UserStatus_export.json
+# core/initial_data/UserStatus.csv
 
 # to apply the seed script:
 # docker-compose exec web python manage.py runscript userstatus-seed
 
+import csv
 import json
 import sys
 from pathlib import Path
@@ -15,13 +16,13 @@ from pathlib import Path
 
 def get_modelname(path):
     filename = Path(path).name
-    return filename.split("_")[0]
+    return filename.split(" - ")[1]
 
 
 def to_values_str(_input):
     values = []
     for key, value in _input.items():
-        if key == "uuid" and isinstance(value, int):
+        if key in ["uuid", "id"] and value.isdigit():
             values.append(f"{value}")
         else:
             values.append(f'"{value}"')
@@ -45,9 +46,30 @@ def to_keys_indexes_str(_input):
     return ", ".join(values)
 
 
-def convert(file_path):
+def to_json(data): # noqa: C901
+    rows_data = []
+    headers = []
+    headers_row = 1
+    for row in data:
+        if headers_row == 1:
+            headers = row
+            headers_row = 0
+        elif row[0]:
+            row_data = {}
+            for i in range(0, len(row)):
+                if row[i]:
+                    row_data[headers[i]] = row[i]
+                else:
+                    row_data[headers[i]] = ""
+            rows_data.append(row_data)
+    
+    return rows_data
+
+
+def convert(file_path): # noqa: C901
     with Path(file_path).open("r") as input_file:
-        input_data = json.load(input_file)
+        csv_data = csv.reader(input_file, delimiter=',')
+        input_data = json.loads(json.dumps(to_json(csv_data)))
         root = Path.cwd()
         model_name = get_modelname(file_path)
 
@@ -71,6 +93,6 @@ if __name__ == "__main__":
     try:
         arg = sys.argv[1]
     except IndexError:
-        raise SystemExit(f"Usage: {sys.argv[0]} <input json file>")
+        raise SystemExit(f"Usage: {sys.argv[0]} <input csv file>")
 
     convert(arg)

--- a/docs/how-to/create-initial-data-migrations.md
+++ b/docs/how-to/create-initial-data-migrations.md
@@ -6,8 +6,8 @@ The goal is to convert our initial data into scripts that can be loaded into the
 
 These are the steps:
 
-1. Export the data into JSON
-1. Generate a python script from the JSON data
+1. Export the data into a csv file
+1. Generate a python script from the csv data
 
 ### Prerequisites
 
@@ -20,24 +20,17 @@ The sheet should be formatted like so:
 - the first row contains the names of the field names in the model. The names must be exactly the same
 - rows 2 to n are the initial data for the model we want to turn into a script.
 
-## Convert the data into JSON
+It is required that there be data in the first column of the sheet.
+
+## Gather data for preparation
 
 1. Export the data from the Google [spreadsheet][pd-data-spreadsheet]
 
     1. Find the sheet in the document containing the data to export. Let's use the `ProgramArea - Data` data as our example.
-    1. Make sure that the first row (column names) is frozen. Otherwise, freeze it by selecting the first row in the sheet, then Menu > View > Freeze > Up to row 1
-    1. Export to JSON. Menu > Export JSON > Export JSON for this sheet
+    1. Go to File -> Download -> Comma Separated Values (.csv). This will download the sheet as a .csv file.
+    1. Copy the file to the app/core/initial_data directory.
 
-1. Save the JSON into a file
-
-    1. Select and copy all the JSON text
-    1. Paste it into a new file and save it as <ModelNameInPascalCase>\_export.json under app/core/initial_data/
-    1. The Pascal case is important in the next step to generate a python script to insert the data. It must match the model's class name for this to work.
-
-    **Potential data issue**
-    There was a problem with the JSON exporter where it omitted the underscore in `occ_code`. It should be fixed now but it's good to pay attention to other column name problems and fix them in the [Google Apps script][apps-script] in the [spreadsheet][pd-data-spreadsheet]. You will find out when the data insertion fails if there's a problem.
-
-## Convert JSON into Python script
+## Convert data into Python script
 
 1. Start Docker
 
@@ -50,7 +43,7 @@ The sheet should be formatted like so:
 1. Go to the project root and run this command
 
     ```bash
-    docker-compose exec web python scripts/convert.py core/initial_data/ProgramArea_export.json
+    docker-compose exec web python scripts/convert.py "core/initial_data/PD_ Table and field explanations  - ProgramArea - Data.csv"
     ```
 
 1. Check that there's a new file called `app/core/scripts/programarea_seed.py` and that it looks correct
@@ -135,5 +128,4 @@ The sheet should be formatted like so:
     operations = [migrations.RunPython(run, migrations.RunPython.noop)]
     ```
 
-[apps-script]: https://thenewstack.io/how-to-convert-google-spreadsheet-to-json-formatted-text/#:~:text=To%20do%20this,%20click%20Extensions,save%20your%20work%20so%20far.
 [pd-data-spreadsheet]: https://docs.google.com/spreadsheets/d/1x_zZ8JLS2hO-zG0jUocOJmX16jh-DF5dccrd_OEGNZ0/


### PR DESCRIPTION
Fixes #144 

### What changes did you make?

- Changed convert script so it gets data from a csv spreadsheet directly. The data is converted to JSON inside the script, removing the step of having to run the Google Apps script for JSON data.
- Made sure id and uuid values are cast to int rather than string while converting from JSON to Python.
- Modified documentation to show how to export the spreadsheet to csv.

### Why did you make the changes (we will use this info to test)?

- Reading directly from the downloaded spreadsheet is simpler than copying the JSON data from the Google Apps script into a new file.
- The Google Apps script does not run for sheets with any missing data.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->

<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

