### PR TITLE
Add seed data permission type 278

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -21,6 +21,7 @@ RUN \
   && apt-get install --no-install-recommends -yqq \
   netcat=1.10-46 \
   gcc=4:10.2.1-1 \
+  postgresql=13+225+deb11u1\
   graphviz=2.42.2-5
 
 # install dependencies

--- a/app/core/initial_data/PermissionType_export.json
+++ b/app/core/initial_data/PermissionType_export.json
@@ -1,0 +1,34 @@
+[
+    {
+        "uuid":1, 
+        "name":"adminGlobal",
+        "description":"Granted to People Depo Admins. Can CRUD anything."},
+    {
+        "uuid":2, 
+        "name":"adminVrms", 
+        "description":"Granted to VRMS the application.  Can R anything and update permissions for users to the level of Admin Brigade"},
+    {
+        "uuid":3, 
+        "name":"adminBrigade", 
+        "description":"Granted to Brigage Leads.  Can CRUD anything related to a user or project assigned to their brigade "},
+    {
+        "uuid":4, 
+        "name":"adminProject", 
+        "description":"Granted to Product Managers.  Can Read and Update anything related to their assigned project"},
+    {
+        "uuid":5, 
+        "name":"practiceLeadProject", 
+        "description":"Granted when a user is promoted or assigned to be a Project Lead.  Can R and U anything related to people in their practice area (must attend lead events)"},
+    {
+        "uuid":6, 
+        "name":"practiceLeadJrProject", 
+        "description":"Granted when a user is promoted or assigned to be a Jr Project Lead.  Can R and U anything related to people in their practice area (should attend lead events)"},
+    {
+        "uuid":7, 
+        "name":"memberProject", 
+        "description":"Granted when a user joins a project.  Can Read anything related to their project that is visible"},
+    {
+        "uuid":8, 
+        "name":"memberGeneral", 
+        "description":"Granted when a user finishes onboaring.  Can express interest in a project's open role if they are the role"}
+]

--- a/app/data/migrations/0004_permissiontype_seed.py
+++ b/app/data/migrations/0004_permissiontype_seed.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+from core.models import PermissionType
+
+
+def run(__code__, __reverse_code__):
+   items = [
+        (1, "adminGlobal", "Granted to People Depo Admins. Can CRUD anything."),
+        (2, "adminVrms", "Granted to VRMS the application.  Can R anything and update permissions for users to the level of Admin Brigade"),
+        (3, "adminBrigade", "Granted to Brigage Leads.  Can CRUD anything related to a user or project assigned to their brigade "),
+        (4, "adminProject", "Granted to Product Managers.  Can Read and Update anything related to their assigned project"),
+        (5, "practiceLeadProject", "Granted when a user is promoted or assigned to be a Project Lead.  Can R and U anything related to people in their practice area (must attend lead events)"),
+        (6, "practiceLeadJrProject", "Granted when a user is promoted or assigned to be a Jr Project Lead.  Can R and U anything related to people in their practice area (should attend lead events)"),
+        (7, "memberProject", "Granted when a user joins a project.  Can Read anything related to their project that is visible"),
+        (8, "memberGeneral", "Granted when a user finishes onboaring.  Can express interest in a project's open role if they are the role"),
+    ]
+
+
+class Migration(migrations.Migration):
+    initial = True
+    dependencies = [("data", "0003_sdg_seed")]
+
+
+operations = [migrations.RunPython(run, migrations.RunPython.noop)]

--- a/app/data/migrations/max_migration.txt
+++ b/app/data/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0003_sdg_seed
+0004_permissiontype_seed


### PR DESCRIPTION
Fixes #replace_this_text_with_the_issue_number

### What changes did you make?

- added json file and migrations file for the seed data
- modified `Dockerfile` to install postgresql during docker-build

### Why did you make the changes (we will use this info to test)?

- For setting up the initial data for `PermissionType` model
- Postgresql is necessary for seeding the data