### PR TITLE
fix(docs): create initial data scripts page

### DIFF
--- a/app/data/migrations/0001_programarea_seed.py
+++ b/app/data/migrations/0001_programarea_seed.py
@@ -3,7 +3,7 @@ from django.db import migrations
 from core.models import ProgramArea
 
 
-def run(__code__, __reverse_code__):
+def forward(__code__, __reverse_code__):
     items = [
         (1, "Citizen Engagement"),
         (2, "Civic Tech Infrastructure"),
@@ -19,8 +19,11 @@ def run(__code__, __reverse_code__):
         ProgramArea.objects.create(uuid=uuid, name=name)
 
 
+def reverse(__code__, __reverse_code__):
+    ProgramArea.objects.all().delete()
+
+
 class Migration(migrations.Migration):
-    initial = True
     dependencies = [("core", "0018_rename_recurringevent_event")]
 
-    operations = [migrations.RunPython(run, migrations.RunPython.noop)]
+    operations = [migrations.RunPython(forward, reverse)]

--- a/app/data/migrations/0002_practicearea_seed.py
+++ b/app/data/migrations/0002_practicearea_seed.py
@@ -2,7 +2,7 @@ from django.db import migrations
 from core.models import PracticeArea
 
 
-def run(__code__, __reverse_code__):
+def forward(__code__, __reverse_code__):
     items = [
         (1, "Development"),
         (2, "Project Management"),
@@ -13,8 +13,11 @@ def run(__code__, __reverse_code__):
         PracticeArea.objects.create(uuid=uuid, name=name)
 
 
+def reverse(__code__, __reverse_code__):
+    PracticeArea.objects.all().delete()
+
+
 class Migration(migrations.Migration):
-    initial = True
     dependencies = [("data", "0001_programarea_seed")]
 
-    operations = [migrations.RunPython(run, migrations.RunPython.noop)]
+    operations = [migrations.RunPython(forward, reverse)]

--- a/app/data/migrations/0003_sdg_seed.py
+++ b/app/data/migrations/0003_sdg_seed.py
@@ -3,7 +3,7 @@ from django.db import migrations
 from core.models import Sdg
 
 
-def run(__code__, __reverse_code__):
+def forward(__code__, __reverse_code__):
     items = [
         (1, "No Poverty", "End poverty in all its forms everywhere", "sdg01.png"),
         (
@@ -107,8 +107,11 @@ def run(__code__, __reverse_code__):
         Sdg.objects.create(uuid=uuid, name=name, description=description, image=image)
 
 
+def reverse(__code__, __reverse_code__):
+    Sdg.objects.all().delete()
+
+
 class Migration(migrations.Migration):
-    initial = True
     dependencies = [("data", "0002_practicearea_seed")]
 
-    operations = [migrations.RunPython(run, migrations.RunPython.noop)]
+    operations = [migrations.RunPython(forward, reverse)]

--- a/docs/how-to/create-initial-data-migrations.md
+++ b/docs/how-to/create-initial-data-migrations.md
@@ -89,18 +89,20 @@ It is required that there be data in the first column of the sheet.
     from core.models import ModelNameInPascalCase
 
 
-    def run(__code__, __reverse_code__):
+    def forward(__code__, __reverse_code__):
         # paste everything in seed script's run function here
         # remove pass below
         pass
 
 
+    def reverse(__code__, __reverse_code__):
+        ModelNameInPascalCase.objects.all().delete()
+
+
     class Migration(migrations.Migration):
-        initial = True
         dependencies = [("data", "<name of last script, or contents of max_migration.txt>")]
 
-
-    operations = [migrations.RunPython(run, migrations.RunPython.noop)]
+        operations = [migrations.RunPython(forward, reverse)]
     ```
 
     For example:
@@ -111,7 +113,7 @@ It is required that there be data in the first column of the sheet.
     from core.models import BookType
 
 
-    def run(__code__, __reverse_code__):
+    def forward(__code__, __reverse_code__):
         items = [
             (1, "Hard Cover"),
             (2, "Soft Cover"),
@@ -120,12 +122,14 @@ It is required that there be data in the first column of the sheet.
             BookType.objects.create(uuid=uuid, name=name)
 
 
+    def reverse(__code__, __reverse_code__):
+        BookType.objects.all().delete()
+
+
     class Migration(migrations.Migration):
-        initial = True
         dependencies = [("data", "0011_author_seed")]
 
-
-    operations = [migrations.RunPython(run, migrations.RunPython.noop)]
+        operations = [migrations.RunPython(forward, reverse)]
     ```
 
 [pd-data-spreadsheet]: https://docs.google.com/spreadsheets/d/1x_zZ8JLS2hO-zG0jUocOJmX16jh-DF5dccrd_OEGNZ0/

--- a/scripts/db.sh
+++ b/scripts/db.sh
@@ -5,4 +5,4 @@ IFS=$'\n\t'
 echo "\q to quit"
 
 set -x
-docker-compose exec db psql -d people_depot_dev -U people_depot
+docker-compose exec db psql -d people_depot_dev -U people_depot "$@"


### PR DESCRIPTION
Fixes #313

### What changes did you make?

code fixes for migration script
- fixed `operations` line indentation
- removed `initial = True`
- added reverse function

### Why did you make the changes (we will use this info to test)?

- broken code in the guide creates bugs in real code
- `initial = True` is for initial migration and shouldn't be used here.
- reverse function allows jumping to different migrations without errors.

### Testing suggestions

1. Visual check of the `operations` line indentation
2. Visual check of the `initial = True`
3. The below lines
```bash
# run the application
./scripts/buildrun.sh

# the SDG model table should have data
./scripts/db.sh -c "select * from core_sdg;"

# reverse the latest data migration (SDG
./scripts/migrate.sh data 0002

# the SDG model table should be empty
./scripts/db.sh -c "select * from core_sdg;"
```
Old page with problem circled
<kbd>![alt-text](https://github.com/hackforla/peopledepot/assets/1160105/6de0f0d9-7661-46ae-9c01-595386271517)</kbd>

New page with changes circled
<kbd>![alt-text](https://github.com/hackforla/peopledepot/assets/1160105/c727b0d3-9a9b-46bd-bae6-085259fc842f)</kbd>