### PR TITLE
Add cognito authentication and API endpoint pages

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -3,6 +3,8 @@ nav:
   - Get Started:
     - CONTRIBUTING.md
   - architecture
+  - ref
+  - howto
   - how-to
   - tools
   - ...

--- a/docs/howto/.pages
+++ b/docs/howto/.pages
@@ -1,0 +1,1 @@
+title: User How-to

--- a/docs/howto/authenticate_cognito.md
+++ b/docs/howto/authenticate_cognito.md
@@ -1,0 +1,48 @@
+# Cognito authentication workflow (pre deployment)
+
+This is a temporary solution until we can deploy a dev environment for PeopleDepot.
+
+There's a few manual steps and the login is good for only an hour at a time.
+
+Prerequisites:
+
+- [ModHeader](https://modheader.com/modheader/download) browser extension
+
+Steps:
+
+1. Login (or register first then login) to a cognito account [here](https://hackforla-vrms-dev.auth.us-west-2.amazoncognito.com/login?client_id=3e3bi1ct2ks9rcktrde8v60v3u&response_type=token&scope=openid&redirect_uri=http://localhost:8000/admin).  Do not worry if you see error messages - you will be using the url.
+
+    [<img src="https://user-images.githubusercontent.com/1160105/184449364-e3bba6e9-ced5-498f-a0e6-0c93c8a036fb.png" width="500" />](https://user-images.githubusercontent.com/1160105/184449364-e3bba6e9-ced5-498f-a0e6-0c93c8a036fb.png)
+
+1. Copy the URL when it redirects. **Note:** Instead of the screen below, the screen may display an error message.  You can ignore any error messages.
+
+    [<img src="https://user-images.githubusercontent.com/1160105/184449368-f16b19de-9372-436c-b65d-c5afadbcbc1a.png" width="500" />](https://user-images.githubusercontent.com/1160105/184449368-f16b19de-9372-436c-b65d-c5afadbcbc1a.png).
+
+1. Extract the `access_token` using the [online tool](https://regexr.com/6ro69).
+
+    1. Clear the top box and paste the URL text into it. The box should show there's 1 match
+    1. The bottom box's content is the extracted `access_token`
+
+    [<img src="https://user-images.githubusercontent.com/1160105/184449537-2a9570a5-6361-48ae-b348-506244d592ac.png" width="500" />](https://user-images.githubusercontent.com/1160105/184449537-2a9570a5-6361-48ae-b348-506244d592ac.png)
+
+1. Open [ModHeader](https://modheader.com/modheader/download).  If the icon is hidden, click on the Puzzle icon in the upper right of the browser to see it.
+
+1. Type the word Bearer and paste the token into [ModHeader](https://docs.modheader.com/using-modheader/introduction) Authorization: Bearer \<access_token>
+
+    [<img src="https://user-images.githubusercontent.com/1160105/184449582-3de548f4-769b-43ac-82b3-06ec2845ead2.png" width="500" />](https://user-images.githubusercontent.com/1160105/184449582-3de548f4-769b-43ac-82b3-06ec2845ead2.png)
+
+1. Go to a page in api/v1/ to see that it allows access
+
+    [<img src="https://user-images.githubusercontent.com/1160105/184449777-36f95985-9e19-4010-ba5f-6f9eb3324c2b.png" width="500" />](https://user-images.githubusercontent.com/1160105/184449777-36f95985-9e19-4010-ba5f-6f9eb3324c2b.png)
+
+1. Explore APIs using [Swagger](http://localhost:8000/api/schema/swagger-ui)
+
+    [<img src="https://user-images.githubusercontent.com/1160105/184449905-43a95335-20b8-4bf4-8a1b-10b95b7c48be.png" width="500" />](https://user-images.githubusercontent.com/1160105/184449905-43a95335-20b8-4bf4-8a1b-10b95b7c48be.png)
+
+1. Some fields have hints on how to retrieve the values.
+
+    [<img src="https://user-images.githubusercontent.com/1160105/184449693-a4b9a0e8-75b2-41f0-b52d-83c8c2c4ac20.png" width="500" />](https://user-images.githubusercontent.com/1160105/184449693-a4b9a0e8-75b2-41f0-b52d-83c8c2c4ac20.png)
+
+1. A redoc ui is also available
+
+    [<img src="https://user-images.githubusercontent.com/1160105/184450043-eb1e4af8-f957-4e85-8959-6863fb1f04bf.png" width="500" />](https://user-images.githubusercontent.com/1160105/184450043-eb1e4af8-f957-4e85-8959-6863fb1f04bf.png)

--- a/docs/ref/.pages
+++ b/docs/ref/.pages
@@ -1,0 +1,1 @@
+title: Reference

--- a/docs/ref/api_endpoints.md
+++ b/docs/ref/api_endpoints.md
@@ -1,0 +1,6 @@
+We're using OpenAPI (swagger) for API documentation. We won't have a public URL for it until it's deployed. A ReDoc interface is also available.
+
+These are the URLs in the local dev environment
+
+- http://localhost:8000/api/schema/swagger-ui/
+- http://localhost:8000/api/schema/redoc/


### PR DESCRIPTION
This is a direct copy from the project wiki. We will modify them separately.

Fixes #355

### What changes did you make?

- copied cognito authentication page to code docs (mkdocs)
- copied API endpoints page to code docs
- deleted pages from the project wiki and unlinked them from [wiki home](https://github.com/hackforla/peopledepot/wiki) and wiki sidebar
  - for what the pages looked like before, see the issue for links to the deleted pages in history

### Why did you make the changes (we will use this info to test)?

- those pages are related to the code so they belong in the code repository
  - **API endpoints** page is in the `Reference` section because that's where the API reference will eventually go. It will replace the page eventually.
  - **Cognito Authentication** page is in the `User How-to` section that's meant for people using our backend. It makes less sense to put it with the `Development Guides`.

### Review suggestion

- The new pages are just copy/paste from the wiki pages. As long as the screenshot pages don't look broken, I think it'll be fine.

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)

<details>
<summary>Visuals after changes are applied</summary>

![2024-08-08 15 03 43 localhost 5321d2418e1c](https://github.com/user-attachments/assets/bba0cefd-00d0-4ec0-82fa-c0bf0d46699b)
![2024-08-08 15 03 10 localhost cb7edcbfe94c](https://github.com/user-attachments/assets/4903da44-ba3b-46ae-9e93-108646e1f12b)

</details>