### PR TITLE
add reverse function to permissiontype initial data migration

### DIFF
--- a/app/data/migrations/0004_permissiontype_seed.py
+++ b/app/data/migrations/0004_permissiontype_seed.py
@@ -3,7 +3,7 @@ from django.db import migrations
 from core.models import PermissionType
 
 
-def run(__code__, __reverse_code__):
+def insert_data(__code__, __reverse_code__):
     items = [
         (1, "adminGlobal", "Granted to People Depo Admins. Can CRUD anything."),
         (
@@ -46,8 +46,11 @@ def run(__code__, __reverse_code__):
         PermissionType.objects.create(uuid=uuid, name=name, description=description)
 
 
+def clear_table(__code__, __reverse_code__):
+    PermissionType.objects.all().delete()
+
+
 class Migration(migrations.Migration):
-    initial = True
     dependencies = [("data", "0003_sdg_seed")]
 
-    operations = [migrations.RunPython(run, migrations.RunPython.noop)]
+    operations = [migrations.RunPython(insert_data, clear_table)]


### PR DESCRIPTION
Fixes #357
- #357

### What changes did you make?

- added reverse function to initial data migration

### Why did you make the changes (we will use this info to test)?

- so that the migration is reversible if needed

### Testing suggestion

- adapted from the [other PR's comment](https://github.com/hackforla/peopledepot/pull/303#issuecomment-2164089083)

```bash
# build and run the container in the right branch
./script/buildrun.sh

# make sure data/0004 migration is applied
docker-compose exec -T web python manage.py showmigrations data

# check permissiontype table data
./scripts/db.sh -c "select * from core_permissiontype;"
# should show 8 rows of data

# unapply the migration
./scripts/migrate.sh data 0003

# check table data
# should show empty table

# reapply the migration
./scripts/migrate.sh data 0004

# check table data
# should show 8 rows again
```