### PR TITLE
Create add-missing-documentation.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-missing-documentation.md
+++ b/.github/ISSUE_TEMPLATE/add-missing-documentation.md
@@ -1,0 +1,31 @@
+---
+name: Add missing documentation
+about: Is our repo missing documentation? Record it here so that it can be added
+title: 'Add missing documentation about [REPLACE WITH TOPIC OF MISSING DOCUMENTATION]'
+labels: 'complexity: missing, feature: docs: PD team documentation, milestone: missing, role: missing,
+  size: missing, s: PD team'
+assignees: ''
+
+---
+
+### Overview
+We are striving to write documentation that helps developers on our team and our stakeholders' teams work smoothly and successfully. 
+
+We need to add [REPLACE WITH WHAT NEEDS ADDING], so that developers can [REPLACE WITH BENEFIT]
+
+### Documentation Notes
+#### What's missing?
+- [REPLACE WITH DESCRIPTION OF WHAT'S MISSING FROM THE DOCUMENTATION]
+   
+####  Where would this information have been useful?
+- [REPLACE WITH LINK TO THE PR/ISSUE/SITUATION THAT PROMPTED THE NEED FOR THIS CHANGE/ADDITION]
+   
+#### Which roles will benefit most from this information?
+- [REPLACE WITH ROLES]
+
+### Action Items
+- [ ] [REPLACE WITH ACTION ITEMS]
+
+### Resources/Instructions/Tags 
+- 1.01 [REPLACE WITH LINKS TO ANY EXTERNAL DOCS THAT MIGHT BE USEFUL (WITH INSTRUCTIONS, IF NEEDED)]
+- 1.0x [REPLACE WITH ANY RELEVANT TAGS e.g., git, django, etc.]

--- a/.github/ISSUE_TEMPLATE/add-missing-documentation.md
+++ b/.github/ISSUE_TEMPLATE/add-missing-documentation.md
@@ -9,23 +9,23 @@ assignees: ''
 ---
 
 ### Overview
-We are striving to write documentation that helps developers on our team and our stakeholders' teams work smoothly and successfully. 
+We are striving to write documentation that helps developers on our team and our stakeholders' teams work smoothly and successfully.
 
 We need to add [REPLACE WITH WHAT NEEDS ADDING], so that developers can [REPLACE WITH BENEFIT]
 
 ### Documentation Notes
 #### What's missing?
 - [REPLACE WITH DESCRIPTION OF WHAT'S MISSING FROM THE DOCUMENTATION]
-   
+
 ####  Where would this information have been useful?
 - [REPLACE WITH LINK TO THE PR/ISSUE/SITUATION THAT PROMPTED THE NEED FOR THIS CHANGE/ADDITION]
-   
+
 #### Which roles will benefit most from this information?
 - [REPLACE WITH ROLES]
 
 ### Action Items
 - [ ] [REPLACE WITH ACTION ITEMS]
 
-### Resources/Instructions/Tags 
+### Resources/Instructions/Tags
 - 1.01 [REPLACE WITH LINKS TO ANY EXTERNAL DOCS THAT MIGHT BE USEFUL (WITH INSTRUCTIONS, IF NEEDED)]
 - 1.0x [REPLACE WITH ANY RELEVANT TAGS e.g., git, django, etc.]


### PR DESCRIPTION
New issue template for team members who find that our repo lacks sufficient information on a topic, and that information might be necessary/useful for developers working on or with PeopleDepot

- Fixes #378 

### What changes did you make?

- New issue template

### Why did you make the changes (we will use this info to test)?

- To enable team members to record missing documentation in such a way that the missing information can subsequently be added to the documentation by another team member