### PR TITLE
Modify db docker service to use the env file

### DIFF
--- a/app/.env.docker-example
+++ b/app/.env.docker-example
@@ -8,7 +8,7 @@ DJANGO_SUPERUSER_PASSWORD=admin
 
 # postgres settings for docker
 POSTGRES_ENGINE=django.db.backends.postgresql
-POSTGRES_DATABASE=people_depot_dev
+POSTGRES_DB=people_depot_dev
 POSTGRES_USER=people_depot
 POSTGRES_PASSWORD=people_depot
 POSTGRES_HOST=db
@@ -16,12 +16,12 @@ POSTGRES_PORT=5432
 DATABASE=postgres
 
 # postgres settings for local development
-# SQL_ENGINE=django.db.backends.postgresql
-# SQL_DATABASE=postgres
-# SQL_USER=
-# SQL_PASSWORD=
-# SQL_HOST=localhost
-# SQL_PORT=5432
+# POSTGRES_ENGINE=django.db.backends.postgresql
+# POSTGRES_DB=postgres
+# POSTGRES_USER=
+# POSTGRES_PASSWORD=
+# POSTGRES_HOST=localhost
+# POSTGRES_PORT=5432
 # DATABASE=postgres
 
 # sqlite settings for local development

--- a/app/.env.docker-example
+++ b/app/.env.docker-example
@@ -6,11 +6,16 @@ DJANGO_SUPERUSER_USERNAME=admin1111
 DJANGO_SUPERUSER_EMAIL=admin@admin.com
 DJANGO_SUPERUSER_PASSWORD=admin
 
-# postgres settings for docker
-SQL_ENGINE=django.db.backends.postgresql
-POSTGRES_DB=people_depot_dev
+# settings for db container environment variables in compose file
 POSTGRES_USER=people_depot
 POSTGRES_PASSWORD=people_depot
+POSTGRES_DB=people_depot_dev
+
+# postgres settings for docker
+SQL_USER=$POSTGRES_USER
+SQL_PASSWORD=$POSTGRES_PASSWORD
+SQL_DATABASE=$POSTGRES_DB
+SQL_ENGINE=django.db.backends.postgresql
 SQL_HOST=db
 SQL_PORT=5432
 DATABASE=postgres
@@ -26,9 +31,9 @@ DATABASE=postgres
 
 # sqlite settings for local development
 # SQL_ENGINE=
-# SQL_DATABASE=POSTGRES_DB
-# SQL_USER=POSTGRES_USER
-# SQL_PASSWORD=POSTGRES_PASSWORD
+# SQL_DATABASE=
+# SQL_USER=
+# SQL_PASSWORD=
 # SQL_HOST=
 # SQL_PORT=
 # DATABASE=

--- a/app/.env.docker-example
+++ b/app/.env.docker-example
@@ -7,28 +7,28 @@ DJANGO_SUPERUSER_EMAIL=admin@admin.com
 DJANGO_SUPERUSER_PASSWORD=admin
 
 # postgres settings for docker
-POSTGRES_ENGINE=django.db.backends.postgresql
+SQL_ENGINE=django.db.backends.postgresql
 POSTGRES_DB=people_depot_dev
 POSTGRES_USER=people_depot
 POSTGRES_PASSWORD=people_depot
-POSTGRES_HOST=db
-POSTGRES_PORT=5432
+SQL_HOST=db
+SQL_PORT=5432
 DATABASE=postgres
 
 # postgres settings for local development
-# POSTGRES_ENGINE=django.db.backends.postgresql
-# POSTGRES_DB=postgres
-# POSTGRES_USER=
-# POSTGRES_PASSWORD=
-# POSTGRES_HOST=localhost
-# POSTGRES_PORT=5432
+# SQL_ENGINE=django.db.backends.postgresql
+# SQL_DATABASE=postgres
+# SQL_USER=
+# SQL_PASSWORD=
+# SQL_HOST=localhost
+# SQL_PORT=5432
 # DATABASE=postgres
 
 # sqlite settings for local development
 # SQL_ENGINE=
-# SQL_DATABASE=
-# SQL_USER=
-# SQL_PASSWORD=
+# SQL_DATABASE=POSTGRES_DB
+# SQL_USER=POSTGRES_USER
+# SQL_PASSWORD=POSTGRES_PASSWORD
 # SQL_HOST=
 # SQL_PORT=
 # DATABASE=

--- a/app/.env.docker-example
+++ b/app/.env.docker-example
@@ -7,12 +7,12 @@ DJANGO_SUPERUSER_EMAIL=admin@admin.com
 DJANGO_SUPERUSER_PASSWORD=admin
 
 # postgres settings for docker
-SQL_ENGINE=django.db.backends.postgresql
-SQL_DATABASE=people_depot_dev
-SQL_USER=people_depot
-SQL_PASSWORD=people_depot
-SQL_HOST=db
-SQL_PORT=5432
+POSTGRES_ENGINE=django.db.backends.postgresql
+POSTGRES_DATABASE=people_depot_dev
+POSTGRES_USER=people_depot
+POSTGRES_PASSWORD=people_depot
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
 DATABASE=postgres
 
 # postgres settings for local development

--- a/app/peopledepot/settings.py
+++ b/app/peopledepot/settings.py
@@ -116,8 +116,8 @@ WSGI_APPLICATION = "peopledepot.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": os.environ.get("SQL_ENGINE", "django.db.backends.postgresql"),
-        "NAME": os.environ.get("SQL_DATABASE", "postgres"),
+        "ENGINE": os.environ.get("SQL_ENGINE", "django.db.backends.sqlite3"),
+        "NAME": os.environ.get("SQL_DATABASE", BASE_DIR / "db.sqlite3"),
         "USER": os.environ.get("SQL_USER", "user"),
         "PASSWORD": os.environ.get("SQL_PASSWORD", "password"),
         "HOST": os.environ.get("SQL_HOST", "localhost"),

--- a/app/peopledepot/settings.py
+++ b/app/peopledepot/settings.py
@@ -116,8 +116,8 @@ WSGI_APPLICATION = "peopledepot.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": os.environ.get("SQL_ENGINE", "django.db.backends.sqlite3"),
-        "NAME": os.environ.get("SQL_DATABASE", BASE_DIR / "db.sqlite3"),
+        "ENGINE": os.environ.get("SQL_ENGINE", "django.db.backends.postgresql"),
+        "NAME": os.environ.get("SQL_DATABASE", "postgres"),
         "USER": os.environ.get("SQL_USER", "user"),
         "PASSWORD": os.environ.get("SQL_PASSWORD", "password"),
         "HOST": os.environ.get("SQL_HOST", "localhost"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - 5432:5432
     env_file:
-      - ./app/.env.docker-example
+      - ./app/.env.docker
   mkdocs:
     image: hackforlaops/mkdocs:latest
     command: mkdocs serve --dev-addr 0.0.0.0:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,10 @@ services:
     image: postgres:13.0-alpine
     volumes:
       - postgres_data:/var/lib/postgresql/data/
-    environment:
-      - POSTGRES_USER=people_depot
-      - POSTGRES_PASSWORD=people_depot
-      - POSTGRES_DB=people_depot_dev
     ports:
       - 5432:5432
+    env_file:
+      - ./app/.env.docker-example
   mkdocs:
     image: hackforlaops/mkdocs:latest
     command: mkdocs serve --dev-addr 0.0.0.0:8000

--- a/docs/contributing/dev_environment.md
+++ b/docs/contributing/dev_environment.md
@@ -19,6 +19,7 @@ Set up two-factor authentication on your account by following this [guide](https
 Before cloning your forked repository to your local machine, you must have Git installed. You can find instructions for installing Git for your operating system [**here**](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
 
 === "Windows"
+
     - we recommend [installing Windows Subsystem for Linux (WSL)](https://code.visualstudio.com/docs/remote/wsl). WSL provides a Linux-compatible environment that can prevent common errors during script execution.
 
     - After setting up WSL, install Git directly from the Linux terminal. This method can help avoid complications that sometimes arise when using Git Bash on Windows.
@@ -32,6 +33,7 @@ Before cloning your forked repository to your local machine, you must have Git i
         !!! tip "Feel free to reach out in the [Hack for LA Slack channel](https://hackforla.slack.com/messages/people-depot/) if you encounter any errors while running scripts on Windows"
 
 === "Mac"
+
     Please note that if you have a Mac the page offers several options (see other option, if you need to conserve hard drive space) including:
 
     - an “easiest” option (this version is fine for our use): This option would take just over 4GB.
@@ -132,6 +134,7 @@ upstream        https://github.com/hackforla/peopledepot.git (push)
 1. Make sure the Docker service is running
 
     === "Docker (Engine)"
+
         ```bash
         sudo systemctl status docker
         ```
@@ -139,6 +142,7 @@ upstream        https://github.com/hackforla/peopledepot.git (push)
         It will show `Active: active (running)` if it's running.
 
     === "Docker Desktop"
+
         1. Start Docker Desktop
         1. Run `docker container ls` to verify Docker Desktop is running. If it is not running you will get the message: `Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`
 

--- a/docs/contributing/howto/add-model-and-api-endpoints.md
+++ b/docs/contributing/howto/add-model-and-api-endpoints.md
@@ -3,6 +3,7 @@
 This guide aims to enable developers with little or no django experience to add django models and API endpoints to the project. Most code examples are followed by detailed explanations.
 
 ??? note "The developer will have exposure to the following in this document"
+
     - python
     - django
     - django rest framework
@@ -22,6 +23,7 @@ Let's start!
 ## Data model
 
 ??? note "TDD test"
+
     1. Write the test
 
         We would like the model to store these data, and to return the name property in the str function.
@@ -117,6 +119,7 @@ class RecurringEvent(AbstractBaseModel):  # (1)!
 1. Always override the `__str__` function to output something more meaningful than the default. It lets us do a quick test of the model by calling `str([model])`. It's also useful for the admin site model list view.
 
 ??? note "Updating models.py for many-to-many relationships"
+
     For adding many-to-many relationships with additional fields, such as `ended_on`, we can add
 
     ```python title="app/core/models.py" linenums="1"
@@ -165,6 +168,7 @@ This generates the database migration files
 ```
 
 ??? note "Test"
+
     Since we overrode the `__str__` function, we need to write a test for it.
 
     1. Add a fixture for the model
@@ -212,6 +216,7 @@ This generates the database migration files
         ```
 
 ??? note "Check and commit"
+
     This is a good place to pause, check, and commit progress.
 
     1. Run pre-commit checks
@@ -274,11 +279,13 @@ Check that everything's working and there are no issues, which should be the cas
     1. Having a misconfigured or buggy custom field could cause the admin site to crash and the developer will need to look at the debug message and resolve it.
 
 ??? note "Test"
+
     1. Feel free to write tests for the admin. There's no example for it yet.
     1. The reason there's no tests is that the admin site is independent of the API functionality, and we're mainly interested in the API part.
     1. When the time comes that we depend on the admin interface, we will need to have tests for the needed functionalities.
 
 ??? note "Check and commit"
+
     This is a good place to pause, check, and commit progress.
 
     1. Run pre-commit checks
@@ -305,6 +312,7 @@ This is code that serializes objects into strings for the API endpoints, and des
 In `app/core/api/serializers.py`
 
 ??? note "Updating serializers.py for many-to-many relationships"
+
     Following the many-to-many relationship between project and recurring event from above,
 
     Update the existing serializer classes
@@ -458,6 +466,7 @@ In `app/core/api/views.py`
         1. It doesn't control permissions the way we want, but we will fix it later.
 
 ??? note "Extended example: Query Params"
+
     This example shows how to add a filter params. It's done for the [user model](https://github.com/hackforla/peopledepot/issues/15) as a [requirement](https://github.com/hackforla/peopledepot/issues/10) from VRMS.
 
     1. Here's a more complex API doc example (this example is using the User model's ViewSet)
@@ -565,6 +574,7 @@ In `app/core/api/urls.py`
             - `reverse("recurring-event-list")` would return `http://localhost:8000/api/v1/recuring-events/`
 
 ??? note "Test"
+
     For the CRUD operations, since we're using `ModelViewSet` where all the actions are provided by `rest_framework` and well-tested, it's not necessary to have test cases for them. But here's an example of one.
 
     In `app/core/tests/test_api.py`
@@ -610,6 +620,7 @@ In `app/core/api/urls.py`
         ```
 
 ??? note "Test many-to-many relationships"
+
     In `app/core/tests/test_api.py`
 
     1. Import API URL
@@ -649,6 +660,7 @@ In `app/core/api/urls.py`
         ```
 
 ??? note "Check and commit"
+
     This is a good place to pause, check, and commit progress.
 
     1. Run pre-commit checks
@@ -665,4 +677,5 @@ In `app/core/api/urls.py`
         ```
 
 ??? note "Push the code and start a PR"
+
     Refer to the [Issues page section on "Push to upstream origin"](issues.md#push-to-upstream-origin-aka-your-fork) onward.

--- a/docs/contributing/tools/docker.md
+++ b/docs/contributing/tools/docker.md
@@ -28,11 +28,13 @@ To restore a database to its original state and remove any data manually added, 
 From Docker:
 
 === "Terminal"
+
     ```bash
     docker-compose down -v
     ```
 
 === "Docker Desktop"
+
     1. Open Containers section
     1. Delete people-db-1 container
     1. Open Images Tab
@@ -57,6 +59,7 @@ For apk, the cache directory is `/var/cache/apk/`. [APK wiki on local cache](htt
 For apt, the cache directory is `/var/cache/apt/`.
 
 ??? info "References"
+
     - [buildkit mount the cache](https://vsupalov.com/buildkit-cache-mount-dockerfile/)
     - [proper usage of mount cache](https://dev.doroshev.com/blog/docker-mount-type-cache/)
     - [mount cache reference](https://docs.docker.com/engine/reference/builder/#run---mounttypecache)

--- a/docs/contributing/tools/mkdocs.md
+++ b/docs/contributing/tools/mkdocs.md
@@ -33,6 +33,7 @@ Here's a list of commonly used MkDocs syntax for quick reference.
 ### [Code Blocks](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/)
 
 === "Example"
+
     ```python title="Code Block"
     @admin.register(RecurringEvent)
     class RecurringEventAdmin(admin.ModelAdmin):
@@ -64,6 +65,7 @@ Here's a list of commonly used MkDocs syntax for quick reference.
     ```
 
 === "Code"
+
     ````
     ```python title="Code Block"
     @admin.register(RecurringEvent)
@@ -99,6 +101,7 @@ Here's a list of commonly used MkDocs syntax for quick reference.
 ### [Code Annotations](https://squidfunk.github.io/mkdocs-material/reference/annotations/)
 
 === "Example"
+
     ```bash
     Click the plus sign --> # (1)!
     ```
@@ -106,6 +109,7 @@ Here's a list of commonly used MkDocs syntax for quick reference.
     1. This is an explanation text
 
 === "Code"
+
     ````
     ``` bash
     Click the plus sign --> # (1)!
@@ -117,18 +121,22 @@ Here's a list of commonly used MkDocs syntax for quick reference.
 ### [Text blocks](https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/details/)
 
 === "Example"
+
     !!! example "Simple Block"
 
     !!! example
         Content Block Text
 
     ??? example "Expandable Block"
+
         Content
 
     ???+ example "Opened Expandable Block"
+
         Content
 
 === "Code"
+
     ```
     !!! example "Simple Block"
 
@@ -145,13 +153,17 @@ Here's a list of commonly used MkDocs syntax for quick reference.
 ### [Tabbed content](https://facelessuser.github.io/pymdown-extensions/extensions/tabbed/)
 
 === "Example"
+
     === "Linux"
+
         linux-specific content
 
     === "Mac"
+
         mac-specific content
 
 === "Code"
+
     ```
     === "Linux"
 
@@ -165,9 +177,11 @@ Here's a list of commonly used MkDocs syntax for quick reference.
 ### [Buttons](https://squidfunk.github.io/mkdocs-material/reference/buttons/)
 
 === "Example"
+
     1. ++ctrl+c++ to quit the local server and stop the container
 
 === "Code"
+
     ```
     1. ++ctrl+c++ to quit the local server and stop the container
     ```


### PR DESCRIPTION
Fixes #309

### What changes did you make?

- moved the environment variables from `docker-compose.yml` file to `.env.docker-example`
- replaced the environment section with `env_file: - ./app/.env.docker-example` in `docker-compose.yml`
- change the django settings (`settings.py`) code to use the database variable names that the db container uses

### Why did you make the changes (we will use this info to test)?

- to update the db Docker container to use the same .env file as the web container, so we avoid hard-coding values in the `docker-compose.yml` file
