### PR TITLE
fix mdformat admonition conflict (464)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -144,8 +144,7 @@ repos:
             docs/license.md$
           )
         additional_dependencies:
-          - mdformat-admon
-          - mdformat-mkdocs[recommended]
+          - mdformat-mkdocs[recommended]>=4.1.2
 
   - repo: local
     hooks:

--- a/docs/contributing/dev_environment.md
+++ b/docs/contributing/dev_environment.md
@@ -63,6 +63,7 @@ You can fork the hackforla/peopledepot repository by clicking <a href="https://g
 . A fork is a copy of the repository that will be placed on your GitHub account.
 
 !!! note "It should create a URL that looks like the following -> `https://github.com/<your_GitHub_user_name>/peopledepot`"
+
     !!! example "For example -> `https://github.com/octocat/peopledepot`"
 
 !!! info "What you have created is a forked copy in a remote version on GitHub. It is not on your local machine yet"

--- a/docs/contributing/team.md
+++ b/docs/contributing/team.md
@@ -5,4 +5,5 @@ This step is optional if this is your first time fixing an issue and you want to
 In the [People-depot Slack channel](https://hackforla.slack.com/messages/people-depot/), send an introductory message with your GitHub `handle/username` asking to be added to the Hack for LA peopledepot GitHub repository, have access to the Google Docs Drive, and Figma.
 
 !!! note "Please do the following once you have accepted the GitHub invite (comes via email or in your GitHub notifications)"
+
     Make your own Hack for LA GitHub organization membership public by following this [guide](https://help.github.com/en/articles/publicizing-or-hiding-organization-membership#changing-the-visibility-of-your-organization-membership).

--- a/docs/contributing/tools/mkdocs.md
+++ b/docs/contributing/tools/mkdocs.md
@@ -125,6 +125,7 @@ Here's a list of commonly used MkDocs syntax for quick reference.
     !!! example "Simple Block"
 
     !!! example
+
         Content Block Text
 
     ??? example "Expandable Block"


### PR DESCRIPTION
Fixes #464

### What changes did you make?

- Pinned mdformat-mkdocs to minimum 4.1.2
- Removed mdformat-admon
- Committed auto-updated md files

### Why did you make the changes (we will use this info to test)?

- Pinning causes developer machines to update to the current version.
- Removing mdformat-admon resolves the conflict.
- The md file updates makes the md files more readable in text form

### Testing suggestion

To show that it fixes the problem for pre-commit.ci, my [preview repo commit log](https://github.com/fyliu/peopledepot-preview/commits/main/) shows pre-commit failing before and passing after the changes. (click on the small X and check mark for link to detailed output)

1. Run pre-commit on all files (should setup mdformat-mkdocs again and pass all checks)

    ```
    pre-commit run --all-files
    ```

1. Check new site for changed md files rendering (the pages should look the same (boxes, dropdowns, tabs))

     - [current site](https://hackforla.github.io/peopledepot/)
     - [preview site](https://fyliu.github.io/peopledepot-preview/)