### PR TITLE
add to ER template to auto mention ER in agenda

### DIFF
--- a/.github/ISSUE_TEMPLATE/emergent-request.md
+++ b/.github/ISSUE_TEMPLATE/emergent-request.md
@@ -30,7 +30,7 @@ assignees: ''
 ### Recommended Action Items
 
 - [ ] Make a new issue
-- [ ] Discuss with team
+- [ ] Discuss with team #461
 - [ ] Let a Team Lead know
 
 ### Potential solutions [draft]


### PR DESCRIPTION
Fixes #replace_this_text_with_the_issue_number

### What changes did you make?

- add a tag to the current agenda issue (#461) in the ER template's todo list item

### Why did you make the changes (we will use this info to test)?

- It automates the step of mentioning the new ER issue in the agenda issue. The mention helps to add the issue for discussion when creating a new agenda.

### Screenshot

<details>
  <summary>what the tagging looks like in the ER issue BEFORE</summary>

![2025-02-13 14 07 46 github com a017bbd8cada](https://github.com/user-attachments/assets/3da557bb-08aa-405b-989e-2d09bf4103be)
</details>

<details>
  <summary>what the tagging looks like in the ER issue AFTER</summary>

![2025-02-13 13 58 04 github com 2d44d693193d](https://github.com/user-attachments/assets/189147e1-893a-4466-b362-02af0fabd584)
</details>

<details>
  <summary>what the tagging looks like in the Agenda issue</summary>

![2025-02-10 12 46 34 github com 572ebb41bea3](https://github.com/user-attachments/assets/d65a0afe-9223-48d7-9304-7b9a0ac03323)
</details>


