### PR TITLE
remove exclusions in mdformat hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,11 +138,6 @@ repos:
     rev: 0.7.19
     hooks:
       - id: mdformat
-        exclude: |
-          (?x)^(
-            docs/index.md$|
-            docs/license.md$
-          )
         additional_dependencies:
           - mdformat-mkdocs[recommended]>=4.1.2
 


### PR DESCRIPTION
Fixes #464

This should have been in the original PR but somehow got left out.

### What changes did you make?

- Removed excludes in the mdformat pre-commit hook

### Why did you make the changes (we will use this info to test)?

- The problem (snippets support) in formatting the excluded files have been resolved in mdformat-mkdocs. 

### Testing

- running `pre-commit run --all-files" should pass