### PR TITLE
480 add a simple page at the site root

### DIFF
--- a/app/peopledepot/urls.py
+++ b/app/peopledepot/urls.py
@@ -1,11 +1,18 @@
 from django.contrib import admin
+from django.http import HttpResponse
 from django.urls import include
 from django.urls import path
 from drf_spectacular.views import SpectacularAPIView
 from drf_spectacular.views import SpectacularRedocView
 from drf_spectacular.views import SpectacularSwaggerView
 
+
+def index(request):
+    return HttpResponse("You're at the peopledepot index.")
+
+
 urlpatterns = [
+    path("", index),
     path("admin/", admin.site.urls),
     path("api/v1/", include("core.api.urls")),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),


### PR DESCRIPTION
The purpose of this is to have a valid page at / to appease the load-balancer so it doesn't spam the logs.

Fixes #480

### What changes did you make?

- added a simple page at "/"

### Why did you make the changes (we will use this info to test)?

- so the load balancer will stop spamming the logs with errors

### Screenshot

#### Before

<kbd>![2025-03-10 15 11 26 peopledepot-dev vrms io f4bb6cc7a7de](https://github.com/user-attachments/assets/98b5d1af-4b66-4b14-8ad2-826690ec49c1)</kbd>

#### After

<kbd>![2025-03-10 15 08 09 localhost b3c3460c5035](https://github.com/user-attachments/assets/6a7a14b6-fdae-4d23-8a33-95829ccf8779)</kbd>
