### PR TITLE
add script to export table descriptions from the database

### DIFF
--- a/scripts/export-table-descriptions.sh
+++ b/scripts/export-table-descriptions.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# Export all table descriptions to CSV
+#
+# Usage: ./export-table-descriptions.sh
+#
+# Output: table-descriptions.csv
+# CSV format: table_name, column_name, data_type, is_nullable
+
+CSV="table-descriptions.csv"
+SQL="\\COPY (SELECT table_name, column_name, data_type, is_nullable
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+      ORDER BY table_name, ordinal_position)
+TO '/$CSV' WITH (FORMAT CSV, HEADER);"
+
+set -x
+docker compose exec db psql -d people_depot_dev -U people_depot -c "$SQL"
+docker compose cp db:/$CSV .


### PR DESCRIPTION
Fixes #495
### What changes did you make?

- A new script that queries the database and exports descriptions for all the tables

### Why did you make the changes (we will use this info to test)?

- We needed a way to automate the manual export and copy steps and make it reusable

### Testing

- run `./scripts/export-table-descriptions.sh`
- open `table-descriptions.csv` file and make sure the data is there