### PR TITLE
Fix link to wiki onboarding page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In the process, it should allow for further automation and do away with manual s
 ## How to contribute
 
 1. Join our organization by going through [Hack for LA Onboarding][hfla onboarding]. It's free to join!
-1. Read the [onboarding section of our Wiki](https://github.com/hackforla/peopledepot/wiki/Developer-Onboarding).
+1. Read the [onboarding section of our Wiki](https://github.com/hackforla/peopledepot/wiki/Technical-Onboarding-for-Developers).
 1. Read our [Contributing Guidelines][contributing] and follow the instructions there.
 
 ## Contact info


### PR DESCRIPTION
Fixes #505 

### What changes did you make?

- fixed link that point to the onboarding page in the wiki

### Why did you make the changes (we will use this info to test)?

- The linked page was renamed

### Review

- Make sure that the new link goes to the correct page.