### PR TITLE
Fix EXE002 linter messages for Windows developers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
     hooks:
       - id: flake8
         exclude: "^app/core/migrations/|^app/data/migrations/|^app/core/scripts"
-        args: [--max-line-length=119, --max-complexity=4, --pytest-fixture-no-parentheses]
+        args: [--max-line-length=119, --max-complexity=4, --pytest-fixture-no-parentheses, --extend-ignore=EXE002]
         additional_dependencies:
           [
             flake8-bugbear,

--- a/docs/contributing/tools/pre-commit.md
+++ b/docs/contributing/tools/pre-commit.md
@@ -68,3 +68,33 @@ It's recommended to install "global" tools via pipx, which installs packages in 
     ```bash
     pre-commit autoupdate
     ```
+
+## Disabled rules
+
+Sometimes, we need to disable a few specific rules that are causing problems. We list them here along with information about them.
+
+??? info "FLAKE8 EXE002"
+
+    This rule is part of flake8's flake8-executable plugin. It checks that all executable scripts have shebangs. This is to ensure that we don't create executable scripts (setting the executable bit) that we don't want to be executable (omitting the shebang).
+
+    We disable this rule for the following reasons:
+
+    1. The rule is broken for NTFS files.
+    1. The rule is a duplicate of the `check-executables-have-shebangs` rule in the `pre-commit-hooks` repo.
+        - that rule [does work with NTFS](https://github.com/pre-commit/pre-commit-hooks/pull/480) by checking the repository metadata for the file, which has the correct executable bit data.
+
+    The rule works correctly in these environments:
+
+    - Windows (WSL)
+    - Linux
+    - macOS
+
+    The rule fails under this specific combination of conditions:
+
+    1. The developer is on a Windows system.
+    1. The developer is using git bash.
+    1. The developer cloned the repository to an NTFS directory (C:\\ or D:) rather than to a linux filesystem (under WSL).
+
+    This rule is broken in the following way:
+
+    1. It asks the operating system to check if the file is executable and checks the file for a shebang. But NTFS does not have the notion of the executable bit, and will always return `True` for all files. So files like `app/core/admin.py` that's not meant to be executable will look like they are executable, and cause the rule to fail, because it doesn't contain a shebang.


### PR DESCRIPTION
Fixes #507

### What changes did you make?

- disabled pre-commit rule EXE002
- added description to the documentation

### Why did you make the changes (we will use this info to test)?

- a certain set of conditions causes a lot of false EXE002 messages for developers on Windows

### Testing

A Windows machine is needed to test this:
- clone the repo onto an NTFS partition
- run pre-commit on the unfixed code to see the problem
- checkout the fix and make sure the messages are done