### PR TITLE
Auto fix to LF line endings in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,8 @@ repos:
 
       # general quality checks
       - id: mixed-line-ending
+        args: [--fix=lf]
+        exclude: ^app/core/initial_data/
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
       - id: check-executables-have-shebangs

--- a/docs/contributing/tools/pre-commit.md
+++ b/docs/contributing/tools/pre-commit.md
@@ -71,6 +71,22 @@ It's recommended to install "global" tools via pipx, which installs packages in 
     pre-commit autoupdate
     ```
 
+## Helpful automations
+
+??? note "Autofix file line endings to LF"
+
+    We use LF line endings since the code is designed to run on Linux. We're forcing this to happen so speed up our PR review process. Individual developers should still set up their editors to use LF line endings.
+
+    We do this via the following lines in `git-commit-hooks`:
+
+    ```bash
+    - id: mixed-line-ending
+    args: [--fix=lf]
+    exclude: ^app/core/initial_data/
+    ```
+
+    Note that we're excluding the initial data from this check for now since we're not decided on the correct line ending there.
+
 ## Disabled rules
 
 Sometimes, we need to disable a few specific rules that are causing problems. We list them here along with information about them.


### PR DESCRIPTION
Fixes #509

### What changes did you make?

- Set pre-commit to fix line endings to LF if contributors try to check in something else
- Exclude initial_data from this rule

### Why did you make the changes (we will use this info to test)?

- Sometimes contributors' editors will change the line endings, but we want to fix it for them in the repo
- The exclusion is because we're not sure if initial data files will break if we set line endings to LF, and we don't want to figure it out right now.

### Testing

1. Open a file in the editor, say `app/core/admin.py`, set line endings to CRLF and save it.
1. See that git diff is the entire file: `git diff`.
1. run `scripts/lint.sh` or `pre-commit run --all-files`.
1. See that the file has been fixed and `git diff` shows no changes.