### PR TITLE
Hide set +x echoes

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -31,33 +31,33 @@ migrate() {
   # Run migrations
 set -x
   "$SCRIPT_DIR"/migrate.sh
-set +x
+{ set +x; } 2>&-;
 }
 
 createsuperuser() {
   # Create superuser
 set -x
   "$SCRIPT_DIR"/createsuperuser.sh
-set +x
+{ set +x; } 2>&-;
 }
 
 logs() {
   # Tail Logs
 set -x
   "$SCRIPT_DIR"/logs.sh
-set +x
+{ set +x; } 2>&-;
 }
 
 dc_down() {
 set -x
   docker-compose down "${DOWN_ARGS[@]}"
-set +x
+{ set +x; } 2>&-;
 }
 
 dc_up() {
 set -x
   docker-compose up "${UP_ARGS[@]}"
-set +x
+{ set +x; } 2>&-;
 }
 
 DOWN_ARGS=()

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -74,13 +74,13 @@ if [ "$CHECK_MIGRATIONS" = true ]; then
   echo "Checking for missing migrations..."
   set -x
   docker-compose exec -T web python manage.py makemigrations --check
-  set +x
+  { set +x; } 2>&-;
 fi
 
 if [ "$EXEC_COMMAND" = true ]; then
   set -x
   docker-compose exec -T web pytest -n "$N_CPU" $COVERAGE "${PYTEST_ARGS[@]}"
-  set +x
+  { set +x; } 2>&-;
 else
   echo docker-compose exec -T web pytest -n "$N_CPU" $COVERAGE "${PYTEST_ARGS[@]}"
 fi


### PR DESCRIPTION
Fixes #517

### What changes did you make?

- Modified scripts to not echo `set +x` commands
   - `scripts/run.sh`
   - `scripts/test.sh`

### Why did you make the changes (we will use this info to test)?

- The lines are unhelpful to see

### Testing

- run the scripts to check that there's no extra echo lines
  - `scripts/buildrun.sh` calls `scripts/run.sh`
  - see screenshots for what my terminal shows

### Screenshots of Proposed Changes

<details>
<summary>before changes - showing extra lines</summary>

<img width="823" height="408" alt="image" src="https://github.com/user-attachments/assets/acff32cf-777a-4304-b6f2-b87e717d13a3" />

</details>

<details>
<summary>after changes - no extra lines</summary>

<img width="738" height="374" alt="image" src="https://github.com/user-attachments/assets/4c1c9b13-9930-4a0c-88f0-5929d4ec2116" />

</details>
