### PR TITLE
docs: convert Joining the team page into a link to the wiki

### DIFF
--- a/docs/contributing/.pages
+++ b/docs/contributing/.pages
@@ -1,6 +1,6 @@
 nav:
   - Onboarding:
-    - team.md
+    - Joining the team: https://github.com/hackforla/peopledepot/wiki/Joining-the-repository-team
     - dev_environment.md
     - issues.md
     - git.md

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -4,7 +4,7 @@ Thank you for volunteering your time! The following is a set of guidelines for c
 
 **Please make sure you have completed the onboarding process which includes joining the Hack for LA Slack, GitHub, and Google Drive. If you have not been onboarded, see the [Getting Started Page](https://www.hackforla.org/getting-started).** _Workshop attendees are granted a temporary exception from this requirement._
 
-- [Joining the team](team.md)
+- [Joining the team](https://github.com/hackforla/peopledepot/wiki/Joining-the-repository-team)
 
 - [Setting up the Development Environment](dev_environment.md)
 

--- a/docs/contributing/team.md
+++ b/docs/contributing/team.md
@@ -1,9 +1,0 @@
-# Joining Repository Team
-
-This step is optional if this is your first time fixing an issue and you want to try fixing an issue without this step.
-
-In the [People-depot Slack channel](https://hackforla.slack.com/messages/people-depot/), send an introductory message with your GitHub `handle/username` asking to be added to the Hack for LA peopledepot GitHub repository, have access to the Google Docs Drive, and Figma.
-
-!!! note "Please do the following once you have accepted the GitHub invite (comes via email or in your GitHub notifications)"
-
-    Make your own Hack for LA GitHub organization membership public by following this [guide](https://help.github.com/en/articles/publicizing-or-hiding-organization-membership#changing-the-visibility-of-your-organization-membership).


### PR DESCRIPTION
Fixes #523

### What changes did you make?

- Moved Joining the team page to the wiki
- Replaced the mkdocs page with a link

### Why did you make the changes (we will use this info to test)?

- We want to keep content separate (wiki for PM, mkdocs for software)

### Screenshots 

#### Page contents

<details>
<summary>mkdocs page before</summary>

<img width="796" height="410" alt="2025-08-27_22-11" src="https://github.com/user-attachments/assets/1e194365-67e8-4f03-b050-e9f436a69933" />

</details>

<details>
<summary>wiki page after</summary>

<img width="973" height="502" alt="2025-08-27_22-12" src="https://github.com/user-attachments/assets/b890e0e8-f2c9-482c-b735-c6918920138c" />

</details>

#### Links

<details>
  <summary>links to the wiki in the same places as before</summary>

<img width="1242" height="1012" alt="2025-08-27_21-57" src="https://github.com/user-attachments/assets/c91208eb-364f-42ef-aabc-5dd8fc9b6b42" />

</details>

<details>
  <summary>new links to page in the wiki</summary>

<img width="1373" height="964" alt="2025-08-27_22-22" src="https://github.com/user-attachments/assets/aff799c7-94b9-4e1e-8024-d4b6c61d714e" />

</details>