### PR TITLE
Remove PM content from MkDocs

### DIFF
--- a/docs/contributing/.pages
+++ b/docs/contributing/.pages
@@ -2,7 +2,7 @@ nav:
   - Onboarding:
     - team.md
     - dev_environment.md
-    - issues.md
+    - code.md
     - git.md
     - documentation.md
   - howto

--- a/docs/contributing/code.md
+++ b/docs/contributing/code.md
@@ -1,17 +1,5 @@
 # Updating Code
 
-## Find an issue
-
-Find an issue in Prioritized Backlog [here](https://github.com/orgs/hackforla/projects/61/views/2)
-
-If you joined the PeopleDepot repository as described in a previous section:
-
-1. Assign the issue to yourself and move it to "In progress" column.
-1. Follow the steps in the issue description to complete the issue.
-1. Make sure to comment your ETA and Availability when you first assign yourself.
-
-If you don't have privileges, add a comment that you are working on the issue.
-
 ## Create a new branch
 
 Once you have selected an issue to work on, create a branch for that issue.
@@ -149,7 +137,3 @@ fixes #<issue-number>
 1. Below this, add a brief description of the changes you made
 1. Click the green "Create pull request" button
 1. Add the PR to the project board
-
-# Creating Issues
-
-To create a new issue, please use the blank issue template (available when you click New Issue). If you want to create an issue for other projects to use, please create the issue in your own repository and send a slack message to one of your hack night hosts with the link.

--- a/docs/contributing/code.md
+++ b/docs/contributing/code.md
@@ -1,4 +1,4 @@
-# Working with Issues
+# Updating Code
 
 ## Find an issue
 

--- a/docs/contributing/howto/add-model-and-api-endpoints.md
+++ b/docs/contributing/howto/add-model-and-api-endpoints.md
@@ -14,7 +14,7 @@ This guide aims to enable developers with little or no django experience to add 
     - API design
     - command line
 
-This guide assumes the developer has followed the [working with issues guide](issues.md) and have forked and created a local branch to work on this. The development server would be already running in the background and will automatically apply the changes when we save the files.
+This guide assumes the developer has followed the [updating code guide](code.md) and have forked and created a local branch to work on this. The development server would be already running in the background and will automatically apply the changes when we save the files.
 
 We will choose the [recurring_event issue](https://github.com/hackforla/peopledepot/issues/14) as an example. Our goal is to create a database table and an API that a client can use to work with the data. The work is split into 3 testable components: the model, the admin site, and the API
 
@@ -675,7 +675,3 @@ In `app/core/api/urls.py`
         git add -A
         git commit -m "feat: add endpoints: recurring_event"
         ```
-
-??? note "Push the code and start a PR"
-
-    Refer to the [Issues page section on "Push to upstream origin"](issues.md#push-to-upstream-origin-aka-your-fork) onward.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -12,7 +12,7 @@ Thank you for volunteering your time! The following is a set of guidelines for c
     - [Fork the repository](dev_environment.md#fork-the-repository)
     - [Build and run locally](dev_environment.md#build-and-run-using-docker-locally)
 
-- [Working with Issues](issues.md)
+- [Updating code](code.md)
 
 - [Working with Git](git.md)
 


### PR DESCRIPTION
Fixes #525

### What changes did you make?

- Page name "Working with Issues" -> "Updating Code"
- Moved "Find an issue" section to the wiki
- Removed "Creating Issues" section

### Why did you make the changes (we will use this info to test)?

- These changes are done to remove PM content from MkDocs.
- "Issues" -> "Code" change is to clarify what the page is about.
- "Creating Issues" section was not useful so it was deleted.
- "Find an issue" is simplified when moved to the wiki

### Screenshots



<details>
<summary>Before</summary>

<kbd><img width="1272" height="1091" alt="2025-08-28_15-27" src="https://github.com/user-attachments/assets/308267e3-2adc-4bf7-bdb9-7e4a35db1eeb" /></kbd>


</details>

<details>
<summary>After</summary>

<kbd><img width="1312" height="965" alt="2025-08-28_15-26" src="https://github.com/user-attachments/assets/e15f5251-89a1-41e6-a039-a4a088a41bb8" /></kbd>
<kbd>
<img width="1282" height="1054" alt="2025-08-28_15-35" src="https://github.com/user-attachments/assets/cc84a6da-5183-4b53-8780-3a379c0f6e60" /></kbd>

</details>
