### PR TITLE
Validate mkdocs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,15 @@
+name: PR Checks
+
+on:
+  pull_request:
+
+jobs:
+  Audit-Pull-Request:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Validate mkdocs
+        run: |
+          docker run --rm -v $(pwd):/app hackforlaops/mkdocs:latest mkdocs build -d /tmp --strict

--- a/docs/architecture/github_actions.md
+++ b/docs/architecture/github_actions.md
@@ -6,12 +6,16 @@ These are the github actions used in the project.
 
 ```bash
 .github/workflows/
-└── deploy-docs.yml # (1)!
+├── deploy-docs.yml # (1)!
+└── pull-request.yml # (2)!
 ```
 
 1. Deploy Documentation
     - triggered by commits to `main`
     - builds and deploys the mkdocs documentation to github pages.
+1. PR Checks
+    - triggered by pull requests
+    - validates the mkdocs build configuration
 
 ## Actions page workflows
 

--- a/docs/contributing/tools/pre-commit.md
+++ b/docs/contributing/tools/pre-commit.md
@@ -8,7 +8,7 @@ The pre-commit checks should be fast while the pre-push hooks will take longer s
 
 It's recommended to install "global" tools via pipx, which installs packages in an isolated environment rather than the global python environment.
 
-1. [Install uv](tools/uv.md)
+1. [Install uv](uv.md)
 
 1. Install pre-commit
 

--- a/docs/contributing/tools/scripts.md
+++ b/docs/contributing/tools/scripts.md
@@ -19,7 +19,8 @@ scripts/
 ├── run.sh
 ├── start-local.sh
 ├── test.sh
-└── update-dependencies.sh
+├── update-dependencies.sh
+└── validate-mkdocs.sh
 ```
 
 These scripts assume you are using bash.
@@ -71,6 +72,8 @@ These scripts assume you are using bash.
     1. use `--help-pytest` to see pytest options that can be added.
 
 1. **update-dependencies.sh** - update python dependencies to the latest versions
+
+1. **validate-mkdocs.sh** - validate mkdocs build for config and link issues
 
 ## Script Elements
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,12 @@ markdown_extensions:
       title: On this page
       permalink: true
 
+validation:
+  absolute_links: relative_to_docs # MkDocs 1.6
+  anchors: warn # MkDocs 1.6
+  omitted_files: warn
+  unrecognized_links: warn
+
 watch:
   - README.md
   - CONTRIBUTING.md

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 IFS=$'\n\t'
-set -x
 
+SCRIPT_DIR="$(dirname "$0")"
+
+set -x
 pre-commit run --all-files --show-diff-on-failure
 
 docker compose exec -T web python manage.py spectacular --file /tmp/schema.yaml --validate
+
+"$SCRIPT_DIR"/validate_mkdocs.sh

--- a/scripts/validate_mkdocs.sh
+++ b/scripts/validate_mkdocs.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eux
+
+# build mkdocs with validation, and don't worry about the output
+docker-compose exec -T mkdocs sh -c "mkdocs build -d /tmp --strict"


### PR DESCRIPTION
Fixes #536

### What changes did you make?

- configured mkdocs validation for maximum strictness
- added script to validate mkdocs
- checked in fix for validation warning
- added GHA workflow to validate mkdocs
- added documentation for the GHA

### Why did you make the changes (we will use this info to test)?

- we need the validation to check the mkdocs build to make sure the mkdocs site deployment works and is free of basic issues like broken internal links

### Testing

1. `validate-mkdocs.sh` - Just run it to test. Maybe re-introduce the validation issue that's been fixed.
2. GHA workflow - use `act` to test.

    1. Install [`act`](https://nektosact.com/installation/index.html).
    1. Run workflow by file.

        ```bash
        act -W '.github/workflows/pull-request.yml'
        ```
    1. Can introduce the validation issue to see it fail.
