### PR TITLE
update ERD link in documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/update-schema.md
+++ b/.github/ISSUE_TEMPLATE/update-schema.md
@@ -46,5 +46,5 @@ Any existing columns that need to be changed are added to the table below (ex: n
 
 ### Resources
 
-- [Entity Relationship Diagram (ERD)](https://lucid.app/lucidchart/ac2f3e81-00d2-4257-b1fc-266d7f0a4cbe/view)
+- [Entity Relationship Diagram (ERD)](https://dbdiagram.io/d/People-Depot-Schema-ERD-68917d4edd90d178656e4061)
 - [PD: Table and field explanations, Field Permissions](https://docs.google.com/spreadsheets/d/1x_zZ8JLS2hO-zG0jUocOJmX16jh-DF5dccrd_OEGNZ0/edit?gid=371053454#gid=371053454)


### PR DESCRIPTION
Fixes #581

### What changes did you make?

- I checked out both repositories and did a find on `erd` and `lucid`, and updated all the places I found.

1. Wiki

   - How-Tos/Create-Table-issues-data-gathering-workflow.md
   - Resources-and-Links.md
   - Technical-Onboarding-for-Developers.md

1. MkDocs

   - .github/ISSUE_TEMPLATE/update-schema.md

### Why did you make the changes (we will use this info to test)?

- The ERD at the old url is outdated and confusing to contributors

### Testing notes

- The wiki pages are updated outside of this PR, so the current links should go to the new location.