### PR TITLE
Update dependabot grouping for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,6 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      dev-deps:
-        dependency-type: "development"
-      prod-deps:
-        dependency-type: "production"
+      python-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
The python dependencies did not group, because we don't have dev vs. prod dependencies yet.