### PR TITLE
docs: update docker install section

### DIFF
--- a/docs/contributing/onboarding/dev_environment.md
+++ b/docs/contributing/onboarding/dev_environment.md
@@ -42,14 +42,11 @@ Before cloning your forked repository to your local machine, you must have Git i
 
 ### Install Docker
 
-Install or make sure [docker][docker-install] and [docker compose][docker-compose-install] are installed on your computer.
+This lets us run our development environment in containers.
 
-```bash
-docker -v
-docker compose -v
-```
+Install using the [recommended installation method for your operating system][docker-install].
 
-The recommended installation method for your operating system can be found [here](https://docs.docker.com/install/).
+- Be sure to perform the "post-install" steps as well, as they will allow you to run Docker without `sudo`.
 
 More on using Docker and the concepts of containerization:
 
@@ -140,20 +137,21 @@ upstream        https://github.com/hackforla/peopledepot.git (push)
 
 1. Make sure the Docker service is running
 
-    === "Docker (Engine)"
+    ```bash
+    docker ps # (1)!
+    ```
 
-        ```bash
-        sudo systemctl status docker
+    1. This should print a list of running containers (it could be empty).
+
+        If it is not running you will get the message:
+
+        ```text
+        Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
         ```
 
-        It will show `Active: active (running)` if it's running.
+        Start Docker or Docker Desktop if the service is not running.
 
-    === "Docker Desktop"
-
-        1. Start Docker Desktop
-        1. Run `docker container ls` to verify Docker Desktop is running. If it is not running you will get the message: `Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`
-
-1. Create an .env.docker file from .env.docker-example
+1. Create `.env.docker`
 
     ```bash
     cp ./app/.env.docker-example ./app/.env.docker
@@ -171,9 +169,10 @@ upstream        https://github.com/hackforla/peopledepot.git (push)
     docker compose exec web python manage.py createsuperuser --no-input
     ```
 
-1. Browse to the web admin interface at `http://localhost:8000/admin/` and confirm the admin site is running. Use DJANGO_SUPERUSER_USERNAME and DJANGO_SUPERUSER_PASSWORD from .env.docker for credentials.
+    This uses `DJANGO_SUPERUSER_USERNAME` and `DJANGO_SUPERUSER_PASSWORD` from `.env.docker` for credentials.
+
+1. Browse to `http://localhost:8000/admin/` to confirm the admin site is running.
 
 See our documentation for [Working with Docker](../tools/docker.md#working-with-docker) for more useful Docker commands.
 
-[docker-compose-install]: https://docs.docker.com/compose/install/
 [docker-install]: https://docs.docker.com/get-docker/


### PR DESCRIPTION
Fixes #645
### What changes did you make?

- mainly adding note to do post-install steps
- see before and after descriptions for other improvements

### Why did you make the changes (we will use this info to test)?

- the post-install is needed for running docker as the normal user
- see before and after descriptions for others

### Screenshots of Proposed Changes

<table>
<tr><td>before</td><td>after</td></tr>

<tr>
 <td><img width="883" height="287" alt="2026-03-05_20-22" src="https://github.com/user-attachments/assets/d0f4fa97-f890-485d-a028-334cec99da22" />
 <td><img width="780" height="265" alt="2026-03-05_20-40" src="https://github.com/user-attachments/assets/2ca6500c-b596-40c9-ba2f-1d3257e3df87" />
<tr>
 <td>
- docker compose not needed anymore, since it's part of docker now.<br>
- installation link target is really small.
 <td>
- added short description of what it does and how it benefits us<br>
- larger installation link<br>
- added note about post-install

<tr>
 <td><img width="905" height="650" alt="2026-03-05_20-19" src="https://github.com/user-attachments/assets/c7d89509-aefd-427e-b44f-ca2596d83b8d" />
 <td><img width="905" height="586" alt="2026-03-05_20-21" src="https://github.com/user-attachments/assets/db0da71f-e12e-4cba-9ba5-ff1ff864e3f4" />
<tr>
 <td>
- complicated docker vs. docker desktop instructions<br>
- systemctl command is not portable across Linuxes.<br>
- step description the same as the command<br>
- long step that should be split up - it' s really 2 things
 <td>
- simplified step that works for both docker and docker desktop<br>
- complexity hidden behind the + sign<br>
- simplified description<br>
- split long step into 2 parts, with better quoting

<tr>
  <td>
  <td><img width="668" height="364" alt="2026-03-05_20-55" src="https://github.com/user-attachments/assets/d8e22a2b-62c2-4970-a9ac-3fc676c0bf6d" />
<tr>
  <td>
  <td>
- content that's shown when clicking on the +<br>
- explains what the command should do, and the common failure case and solution that includes both docker and docker desktop.
</table>