### PR TITLE
set unpriviledged user for Dockerfile

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,6 +1,10 @@
 # pull official base image
 FROM python:3.10-alpine
 
+# create non-root user and group
+RUN addgroup -g 1000 app && \
+  adduser -D -u 1000 -G app -h /home/app -s /bin/sh app
+
 # set work directory
 WORKDIR /usr/src/app
 
@@ -21,7 +25,7 @@ COPY Roboto-Regular.ttf /root/.fonts/
 RUN fc-cache -f
 
 # install dependencies
-COPY ./requirements.txt .
+COPY --chown=app:app ./requirements.txt .
 # hadolint ignore=DL3042
 RUN \
   --mount=type=cache,target=/root/.cache \
@@ -29,12 +33,12 @@ RUN \
   && uv pip install --system -r requirements.txt
 
 # copy entrypoint.sh
-COPY ./entrypoint.sh .
+COPY --chown=app:app ./entrypoint.sh .
 RUN sed -i 's/\r$//g' /usr/src/app/entrypoint.sh \
   && chmod +x /usr/src/app/entrypoint.sh
 
 # copy project
-COPY . .
+COPY --chown=app:app . .
 
 # run entrypoint.sh
 ENTRYPOINT ["/usr/src/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   web:
+    user: "1000:1000"
     build: ./app
     platform: linux/amd64
     command: python manage.py runserver 0.0.0.0:8000

--- a/docs/architecture/docker.md
+++ b/docs/architecture/docker.md
@@ -1,0 +1,21 @@
+---
+tags:
+  - Docker
+---
+
+# Docker configuration
+
+## Docker Compose
+
+The project uses docker compose to run a local development environment.
+
+The compose file is stored in the root of the project.
+
+## Dockerfile
+
+The Dockerfile is stored in the `app/` directory.
+
+## Design
+
+- We run Docker containers as a non-root user.
+    - This is necessary for creating migration files not owned by root and usable by the normal user.

--- a/docs/contributing/tools/index.md
+++ b/docs/contributing/tools/index.md
@@ -3,7 +3,7 @@
 These are the tools we use in the PeopleDepot project with notes on how we use them.
 
 - [Convenience scripts](scripts.md)
-- [Docker](docker.md) for containerization
+- [Docker](./docker.md) for containerization
 - [MkDocs](mkdocs.md) for documentation
 - [Pre-commit](pre-commit.md) for linting
 - [Uv](uv.md) for fast dependency resolution

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ plugins:
         - migrations
         - AWS
         - deployment
+        - Docker
 
 markdown_extensions:
   - abbr


### PR DESCRIPTION
Fixes #647

### What changes did you make?

- added non-root user in Dockerfile
- set non-root user to run the Docker Compose container
- added short description in documentation

### Why did you make the changes (we will use this info to test)?

- these are all pieces to convert containers to run as a non-root user
- Running the containers as non-root allows the `scripts/migrate.sh` script to generate migrations with non-root owner. The root ownership of the migration files interfere with pre-commit running locally. 

### Testing

1. Run ./scripts/buildrun.sh to make sure there are no errors
2. Run `docker compose logs mkdocs` to make sure there are no errors.