### PR TITLE
Replace flake8 hooks with ruff ones

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,21 +62,12 @@ repos:
     hooks:
       - id: flake8
         exclude: "^app/core/migrations/|^app/data/migrations/|^app/core/scripts"
-        args: [--max-line-length=119, --max-complexity=4, --pytest-fixture-no-parentheses, --extend-ignore=EXE002]
+        args: [--max-line-length=119, --max-complexity=4]
         additional_dependencies:
           [
-            flake8-bugbear,
             dlint,
             flake8-use-fstring,
-            flake8-builtins,
-            pep8-naming,
             flake8-variables-names,
-            flake8-fixme,
-            flake8-executable,
-            flake8-pytest-style,
-            flake8-django,
-            flake8-comprehensions,
-            flake8-tidy-imports,
           ]
 
   - repo: https://github.com/pycqa/isort
@@ -114,8 +105,19 @@ repos:
     rev: v0.15.9
     hooks:
       # Run the linter.
-      - id: ruff
-        args: [--fix]
+      - id: ruff-check
+        args: [--fix, --select,
+          B, # flake8-bugbear
+          A, # flake8-builtin
+          C4, # flake8-comprehensions
+          DJ, # flake8-django
+          EXE, # flake8-executable
+          FIX, # flake8-fixme
+          PT, # flake8-pytest-style
+          TID, # flake8-tidy-imports
+          PTH, # flake8-use-pathlib
+          N, # pep8-naming
+        ]
         exclude: ^app/core/migrations/
       # Run the formatter.
       - id: ruff-format

--- a/app/core/utils/jwt.py
+++ b/app/core/utils/jwt.py
@@ -29,7 +29,7 @@ def cognito_jwt_decode_handler(token):
         public_key = RSAAlgorithm.from_jwk(api_settings.JWT_PUBLIC_KEY[kid])
     except KeyError:
         # in this place we could refresh cached jwks and try again
-        raise DecodeError("Can't find proper public key in jwks")
+        raise DecodeError("Can't find proper public key in jwks") from KeyError
     else:
         return jwt.decode(
             token,

--- a/app/data/migrations/0014_socminor_seed.py
+++ b/app/data/migrations/0014_socminor_seed.py
@@ -179,9 +179,9 @@ def forward(__code__, __reverse_code__):
         (91, "22", "53-6000", "Other Transportation Workers"),
         (92, "22", "53-7000", "Material Moving Workers"),
     ]
-    for id, soc_major_id, occ_code, title in items:
+    for uuid, soc_major_id, occ_code, title in items:
         SocMinor.objects.create(
-            uuid=id,
+            uuid=uuid,
             soc_major=SocMajor.objects.get(uuid=int(soc_major_id)),
             occ_code=occ_code,
             title=title,

--- a/app/data/migrations/0015_socbroad_seed.py
+++ b/app/data/migrations/0015_socbroad_seed.py
@@ -772,9 +772,9 @@ def forward(__code__, __reverse_code__):
         (424, "92", "53-7120", "Tank Car, Truck, and Ship Loaders"),
         (425, "92", "53-7190", "Miscellaneous Material Moving Workers"),
     ]
-    for id, soc_minor_id, occ_code, title in items:
+    for uuid, soc_minor_id, occ_code, title in items:
         SocBroad.objects.create(
-            uuid=id,
+            uuid=uuid,
             soc_minor=SocMinor.objects.get(uuid=int(soc_minor_id)),
             occ_code=occ_code,
             title=title,

--- a/app/data/migrations/0016_socdetailed_seed.py
+++ b/app/data/migrations/0016_socdetailed_seed.py
@@ -5489,9 +5489,9 @@ def forward(__code__, __reverse_code__):
         ),
     ]
 
-    for id, soc_broad_id, occ_code, title, description in items:
+    for uuid, soc_broad_id, occ_code, title, description in items:
         SocDetailed.objects.create(
-            uuid=id,
+            uuid=uuid,
             soc_broad=SocBroad.objects.get(uuid=int(soc_broad_id)),
             occ_code=occ_code,
             title=title,

--- a/app/scripts/convert.py
+++ b/app/scripts/convert.py
@@ -96,6 +96,6 @@ if __name__ == "__main__":
     try:
         arg = sys.argv[1]
     except IndexError:
-        raise SystemExit(f"Usage: {sys.argv[0]} <input csv file>")
+        raise SystemExit(f"Usage: {sys.argv[0]} <input csv file>")  # noqa
 
     convert(arg)


### PR DESCRIPTION
Fixes #662

### What changes did you make?

- replaced flake8-django with ruff rules
- replaced other equivalent flake8 plugins with ruff

### Why did you make the changes (we will use this info to test)?

- Switching to ruff rules solves the problem with flake8-django being outdated with python syntax.
- The other replacements are straightforward so I added them.
- There's a few minor fixes necessary for what the ruff version found.

### Testing suggestion

- Run the build and test scripts to make sure they still work.
- Run pre-commit to make sure it passes.