### PR TITLE
Add private boolean field to location table

### DIFF
--- a/app/core/api/serializers.py
+++ b/app/core/api/serializers.py
@@ -277,7 +277,7 @@ class LocationSerializer(serializers.ModelSerializer):
             "state",
             "zip",
             "phone",
-            "private"
+            "private",
         )
         read_only_fields = (
             "uuid",

--- a/app/core/api/serializers.py
+++ b/app/core/api/serializers.py
@@ -277,6 +277,7 @@ class LocationSerializer(serializers.ModelSerializer):
             "state",
             "zip",
             "phone",
+            "private"
         )
         read_only_fields = (
             "uuid",

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -318,6 +318,7 @@ class Location(AbstractBaseModel):
     state = models.CharField(max_length=2, unique=False)
     zipcode = models.CharField(max_length=10, unique=False)
     phone = PhoneNumberField(blank=True)
+    private = models.BooleanField(null=True)
 
     def __str__(self):
         return f"{self.name}"


### PR DESCRIPTION
Fixes [#610](https://github.com/hackforla/peopledepot/issues/610)

### What changes did you make?

Added a new boolean field, "private", to the location table.

Updated table description:

```
Table "public.core_location"

Column   |      Type      | Collation | Nullable | Default 
----------------+--------------------------+-----------+----------+---------
uuid      | uuid           |      | not null | 
created_at   | timestamp with time zone |      | not null | 
updated_at   | timestamp with time zone |      | not null | 
name      | character varying(255)  |      | not null | 
address_line_1 | character varying(255)  |      | not null | 
address_line_2 | character varying(255)  |      | not null | 
city      | character varying(100)  |      | not null | 
state     | character varying(2)   |      | not null | 
zipcode    | character varying(10)  |      | not null | 
phone     | character varying(128)  |      | not null | 
private    | boolean         |      |     | 
Indexes:
"core_location_pkey" PRIMARY KEY, btree (uuid)
"core_location_name_40ac8adc_like" btree (name varchar_pattern_ops)
"core_location_name_key" UNIQUE CONSTRAINT, btree (name)
```

### Why did you make the changes (we will use this info to test)?

We want to add a private boolean flag to the location table to control if someone's location is private or not.