### PR TITLE
integrated whitenoise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ erd.png
 docs/build
 
 *.pyc
+.notes
+app/staticfiles/

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -14,4 +14,6 @@ fi
 # python manage.py flush --no-input
 # python manage.py migrate
 
+python manage.py collectstatic --no-input
+
 exec "$@"

--- a/app/peopledepot/settings.py
+++ b/app/peopledepot/settings.py
@@ -92,6 +92,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -172,6 +173,15 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field

--- a/app/requirements.in
+++ b/app/requirements.in
@@ -12,3 +12,4 @@ pytest-cov
 pytest-django
 pytest-xdist
 tzdata
+whitenoise

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -6,7 +6,7 @@ attrs==24.2.0
     #   referencing
 cffi==1.17.1
     # via cryptography
-coverage[toml]==7.6.8
+coverage==7.6.8
     # via pytest-cov
 cryptography==44.0.1
     # via pyjwt
@@ -24,7 +24,7 @@ django-extensions==3.2.3
     # via -r requirements.in
 django-linear-migrations==2.16.0
     # via -r requirements.in
-django-phonenumber-field[phonenumbers]==8.0.0
+django-phonenumber-field==8.0.0
     # via -r requirements.in
 django-timezone-field==7.0
     # via -r requirements.in
@@ -59,10 +59,8 @@ psycopg2-binary==2.9.10
     # via -r requirements.in
 pycparser==2.22
     # via cffi
-pyjwt[crypto]==2.10.1
-    # via
-    #   drf-jwt
-    #   pyjwt
+pyjwt==2.10.1
+    # via drf-jwt
 pytest==8.3.4
     # via
     #   pytest-cov
@@ -90,3 +88,5 @@ tzdata==2024.2
     # via -r requirements.in
 uritemplate==4.1.1
     # via drf-spectacular
+whitenoise==6.12.0
+    # via -r requirements.in


### PR DESCRIPTION
Fixes #670

### What changes did you make?


# drake_670_integrate_whitenoise
Serve static files via WhiteNoise in the local Docker dev environment for production-like behavior.

# altered
## app/peopledepot/settings.py
Added WhiteNoiseMiddleware immediately after SecurityMiddleware:
```
"whitenoise.middleware.WhiteNoiseMiddleware",
```
Added static file settings:
```
STATIC_ROOT = BASE_DIR / "staticfiles"
STORAGES = {
    "default": {
        "BACKEND": "django.core.files.storage.FileSystemStorage",
    },
    "staticfiles": {
        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
    },
}
```

## app/entrypoint.sh
Runs `collectstatic` on every container start so `staticfiles/` is always populated before Django serves requests:
```
python manage.py collectstatic --no-input
```

# summary
On branch drake_670_integrate_whitenoise
        modified:   .gitignore
        modified:   app/entrypoint.sh
        modified:   app/peopledepot/settings.py
        modified:   app/requirements.in
        modified:   app/requirements.txt
