### PR TITLE
Update UserEmploymentHistory model #618

### DIFF
--- a/app/core/admin.py
+++ b/app/core/admin.py
@@ -417,9 +417,13 @@ class UserCheckAdmin(admin.ModelAdmin):
 
 @admin.register(UserEmploymentHistory)
 class UserEmploymentHistoryAdmin(admin.ModelAdmin):
-    list_display = ("user", "title", "soc_detailed", "created_at")
-    search_fields = ("title", "user__username", "user__email")
-    list_filter = ("soc_detailed",)
+    list_display = ("user", "modern_job_title", "created_at")
+    search_fields = (
+        "modern_job_title__title",
+        "user__username",
+        "user__email",
+    )
+    list_filter = ("modern_job_title",)
 
 
 @admin.register(Win)

--- a/app/core/api/serializers.py
+++ b/app/core/api/serializers.py
@@ -678,7 +678,7 @@ class UserEmploymentHistorySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = UserEmploymentHistory
-        fields = ("uuid", "user", "soc_detailed", "title")
+        fields = ("uuid", "user", "modern_job_title")
         read_only_fields = ("uuid", "created_at", "updated_at")
 
 

--- a/app/core/migrations/0063_remove_useremploymenthistory_soc_detailed_and_more.py
+++ b/app/core/migrations/0063_remove_useremploymenthistory_soc_detailed_and_more.py
@@ -1,0 +1,66 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def populate_modern_job_title(apps, schema_editor):
+    UserEmploymentHistory = apps.get_model("core", "UserEmploymentHistory")
+    ModernJobTitle = apps.get_model("core", "ModernJobTitle")
+
+    for history in UserEmploymentHistory.objects.all():
+        modern_job_title = ModernJobTitle.objects.filter(
+            soc_detailed_id=history.soc_detailed_id,
+            title=history.title,
+        ).first()
+
+        if modern_job_title is None:
+            modern_job_title = ModernJobTitle.objects.create(
+                soc_detailed_id=history.soc_detailed_id,
+                title=history.title,
+            )
+
+        history.modern_job_title_id = modern_job_title.pk
+        history.save(update_fields=["modern_job_title"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('core', '0062_permission_ended_permission_granted')]
+
+    operations = [
+        migrations.AddField(
+            model_name="useremploymenthistory",
+            name="modern_job_title",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="user_employment_histories",
+                to="core.modernjobtitle",
+            ),
+        ),
+        migrations.RunPython(
+            populate_modern_job_title,
+            migrations.RunPython.noop,
+        ),
+        migrations.RunSQL(
+            "SET CONSTRAINTS ALL IMMEDIATE",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RemoveField(
+            model_name="useremploymenthistory",
+            name="soc_detailed",
+        ),
+        migrations.RemoveField(
+            model_name="useremploymenthistory",
+            name="title",
+        ),
+        migrations.AlterField(
+            model_name="useremploymenthistory",
+            name="modern_job_title",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="user_employment_histories",
+                to="core.modernjobtitle",
+            ),
+        ),
+    ]

--- a/app/core/migrations/max_migration.txt
+++ b/app/core/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0062_permission_ended_permission_granted
+0063_remove_useremploymenthistory_soc_detailed_and_more

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -886,16 +886,14 @@ class UserEmploymentHistory(AbstractBaseModel):
         related_name="employment_histories",
     )
 
-    soc_detailed = models.ForeignKey(
-        "SOCDetailed",
+    modern_job_title = models.ForeignKey(
+        ModernJobTitle,
         on_delete=models.CASCADE,
         related_name="user_employment_histories",
     )
 
-    title = models.CharField(max_length=255)
-
     def __str__(self):
-        return f"{self.user.username} - {self.title}"
+        return f"{self.user.username} - {self.modern_job_title}"
 
 
 class Win(AbstractBaseModel):

--- a/app/core/tests/conftest.py
+++ b/app/core/tests/conftest.py
@@ -488,11 +488,10 @@ def user_check(user, organization, check_type, project):
 
 
 @pytest.fixture
-def user_employment_history(db, user, soc_detailed):
+def user_employment_history(db, user, modern_job_title):
     return UserEmploymentHistory.objects.create(
         user=user,
-        soc_detailed=soc_detailed,
-        title="Software Engineer",
+        modern_job_title=modern_job_title,
     )
 
 

--- a/app/core/tests/test_api.py
+++ b/app/core/tests/test_api.py
@@ -1287,11 +1287,10 @@ def test_api_allow_org_and_project_same_type_different_scopes(
     assert r2.status_code == status.HTTP_201_CREATED
 
 
-def test_list_user_employment_histories(auth_client, user, soc_detailed):
+def test_list_user_employment_histories(auth_client, user, modern_job_title):
     payload = {
         "user": user.pk,
-        "soc_detailed": soc_detailed.pk,
-        "title": "Software Engineer",
+        "modern_job_title": modern_job_title.pk,
     }
     auth_client.post(USER_EMPLOYMENT_HISTORIES_URL, payload)
 
@@ -1304,11 +1303,10 @@ def test_list_user_employment_histories(auth_client, user, soc_detailed):
     assert res.data == expected_data
 
 
-def test_create_user_employment_history(auth_client, user, soc_detailed):
+def test_create_user_employment_history(auth_client, user, modern_job_title):
     payload = {
         "user": user.pk,
-        "soc_detailed": soc_detailed.pk,
-        "title": "Backend Engineer",
+        "modern_job_title": modern_job_title.pk,
     }
 
     res = auth_client.post(USER_EMPLOYMENT_HISTORIES_URL, payload)
@@ -1317,8 +1315,7 @@ def test_create_user_employment_history(auth_client, user, soc_detailed):
 
     created = UserEmploymentHistory.objects.get(uuid=res.data["uuid"])
     assert created.user == user
-    assert created.soc_detailed.pk == payload["soc_detailed"]
-    assert created.title == payload["title"]
+    assert created.modern_job_title == modern_job_title
 
 
 def test_retrieve_user_employment_history(auth_client, user_employment_history):
@@ -1327,8 +1324,7 @@ def test_retrieve_user_employment_history(auth_client, user_employment_history):
 
     assert res.status_code == status.HTTP_200_OK
     assert res.data["uuid"] == str(user_employment_history.pk)
-    assert res.data["title"] == user_employment_history.title
-    assert res.data["soc_detailed"] == user_employment_history.soc_detailed.pk
+    assert res.data["modern_job_title"] == user_employment_history.modern_job_title.pk
     assert res.data["user"] == user_employment_history.user.pk
 
 

--- a/app/core/tests/test_models.py
+++ b/app/core/tests/test_models.py
@@ -759,48 +759,62 @@ def test_usercheck_cross_scopes_allowed_simultaneously(
     assert project_user_check.pk is not None
 
 
-def test_create_user_employment_history(user, soc_detailed):
+def test_create_user_employment_history(user, modern_job_title):
     history = UserEmploymentHistory.objects.create(
         user=user,
-        soc_detailed=soc_detailed,
-        title="Backend Engineer",
+        modern_job_title=modern_job_title,
     )
 
     assert history.uuid is not None
     assert history.user == user
-    assert history.soc_detailed == soc_detailed
-    assert history.title == "Backend Engineer"
+    assert history.modern_job_title == modern_job_title
 
 
-def test_user_can_have_multiple_employment_histories(user, soc_detailed):
+def test_user_can_have_multiple_employment_histories(user, modern_job_title):
     history1 = UserEmploymentHistory.objects.create(
         user=user,
-        soc_detailed=soc_detailed,
-        title="Software Engineer",
+        modern_job_title=modern_job_title,
     )
     history2 = UserEmploymentHistory.objects.create(
         user=user,
-        soc_detailed=soc_detailed,
-        title="Senior Software Engineer",
+        modern_job_title=modern_job_title,
     )
 
     histories = user.employment_histories.all()
 
-    assert histories.count() == 2
     assert history1 in histories
     assert history2 in histories
+    assert histories.count() == 2
 
 
-def test_user_deletion_cascades_to_employment_histories(user, soc_detailed):
+def test_user_deletion_cascades_to_employment_histories(user, modern_job_title):
     UserEmploymentHistory.objects.create(
         user=user,
-        soc_detailed=soc_detailed,
-        title="Software Engineer",
+        modern_job_title=modern_job_title,
     )
+
+    assert UserEmploymentHistory.objects.count() == 1
 
     user.delete()
 
     assert UserEmploymentHistory.objects.count() == 0
+
+
+def test_modern_job_title_has_multiple_employment_histories(user, modern_job_title):
+    history1 = UserEmploymentHistory.objects.create(
+        user=user,
+        modern_job_title=modern_job_title,
+    )
+    history2 = UserEmploymentHistory.objects.create(
+        user=user,
+        modern_job_title=modern_job_title,
+    )
+
+    histories = modern_job_title.user_employment_histories.all()
+
+    assert history1 in histories
+    assert history2 in histories
+    assert histories.count() == 2
 
 
 def test_model_prevent_duplicate_global_usercheck(user, check_type):


### PR DESCRIPTION
Fixes #618

### What changes did you make?

- Updated `UserEmploymentHistory` to replace `title` with a `modern_job_title` foreign key to `ModernJobTitle`.
- Removed the `soc_detailed` field from `UserEmploymentHistory`.
- Added a data migration to preserve existing employment history data by mapping the previous `title` and `soc_detailed` values to `ModernJobTitle`.
- Updated the admin configuration, serializer, fixtures, model tests, and API tests for the new relationship.

### Why did you make the changes (we will use this info to test)?

- `UserEmploymentHistory` should reference the existing `ModernJobTitle` model instead of storing a separate job title and SOC relationship.
- Existing `UserEmploymentHistory` records are migrated to the corresponding `ModernJobTitle` relationship.
- The API now accepts and returns `modern_job_title` as the foreign key.
- Tests verify creation, retrieval, reverse relationships, and cascade behavior.


- Updated the `UserEmploymentHistory` database schema. See the [UserEmploymentHistory Schema Table Description]
https://github.com/hackforla/peopledepot/issues/618#issuecomment-5351126380