### PR TITLE
refactor: rename SOC* and SDGTargetIndicator  classes and related vie…

### DIFF
--- a/app/core/admin.py
+++ b/app/core/admin.py
@@ -28,12 +28,12 @@ from .models import ProjectUrl
 from .models import Referrer
 from .models import ReferrerType
 from .models import Sdg
-from .models import SdgTargetIndicator
+from .models import SDGTargetIndicator
 from .models import Skill
-from .models import SocBroad
-from .models import SocDetailed
-from .models import SocMajor
-from .models import SocMinor
+from .models import SOCBroad
+from .models import SOCDetailed
+from .models import SOCMajor
+from .models import SOCMinor
 from .models import StackElement
 from .models import StackElementType
 from .models import UrlStatusType
@@ -273,8 +273,8 @@ class SdgAdmin(admin.ModelAdmin):
     list_display = ("name", "description", "image")
 
 
-@admin.register(SdgTargetIndicator)
-class SdgTargetIndicatorAdmin(admin.ModelAdmin):
+@admin.register(SDGTargetIndicator)
+class SDGTargetIndicatorAdmin(admin.ModelAdmin):
     list_display = (
         "sdg",
         "code",
@@ -313,27 +313,27 @@ class ProjectProgramAreaStatusTypeAdmin(admin.ModelAdmin):
     list_display = ("name", "description")
 
 
-@admin.register(SocBroad)
-class SocBroadAdmin(admin.ModelAdmin):
+@admin.register(SOCBroad)
+class SOCBroadAdmin(admin.ModelAdmin):
     list_display = ("title", "occ_code", "soc_minor")
     list_filter = ("soc_minor",)
     search_fields = ("title", "occ_code")
 
 
-@admin.register(SocDetailed)
-class SocDetailedAdmin(admin.ModelAdmin):
+@admin.register(SOCDetailed)
+class SOCDetailedAdmin(admin.ModelAdmin):
     list_display = ("occ_code", "title", "soc_broad", "created_at")
     search_fields = ("occ_code", "title", "soc_broad__title")
     list_filter = ("soc_broad",)
 
 
-@admin.register(SocMajor)
-class SocMajorAdmin(admin.ModelAdmin):
+@admin.register(SOCMajor)
+class SOCMajorAdmin(admin.ModelAdmin):
     list_display = ("occ_code", "title")
 
 
-@admin.register(SocMinor)
-class SocMinorAdmin(admin.ModelAdmin):
+@admin.register(SOCMinor)
+class SOCMinorAdmin(admin.ModelAdmin):
     list_display = ("soc_major", "occ_code", "title")
 
 

--- a/app/core/api/serializers.py
+++ b/app/core/api/serializers.py
@@ -23,12 +23,12 @@ from core.models import ProjectUrl
 from core.models import Referrer
 from core.models import ReferrerType
 from core.models import Sdg
-from core.models import SdgTargetIndicator
+from core.models import SDGTargetIndicator
 from core.models import Skill
-from core.models import SocBroad
-from core.models import SocDetailed
-from core.models import SocMajor
-from core.models import SocMinor
+from core.models import SOCBroad
+from core.models import SOCDetailed
+from core.models import SOCMajor
+from core.models import SOCMinor
 from core.models import StackElement
 from core.models import StackElementType
 from core.models import UrlStatusType
@@ -392,9 +392,9 @@ class StackElementTypeSerializer(serializers.ModelSerializer):
         )
 
 
-class SdgSerializer(serializers.ModelSerializer):
+class SDGSerializer(serializers.ModelSerializer):
     """
-    Used to retrieve Sdg
+    Used to retrieve SDG
     """
 
     projects = serializers.StringRelatedField(many=True)
@@ -415,9 +415,9 @@ class SdgSerializer(serializers.ModelSerializer):
         )
 
 
-class SdgTargetIndicatorSerializer(serializers.ModelSerializer):
+class SDGTargetIndicatorSerializer(serializers.ModelSerializer):
     class Meta:
-        model = SdgTargetIndicator
+        model = SDGTargetIndicator
         fields = (
             "uuid",
             "sdg",
@@ -471,9 +471,9 @@ class ProjectProgramAreaStatusTypeSerializer(serializers.ModelSerializer):
         read_only_fields = ("uuid", "created_at", "updated_at")
 
 
-class SocBroadSerializer(serializers.ModelSerializer):
+class SOCBroadSerializer(serializers.ModelSerializer):
     class Meta:
-        model = SocBroad
+        model = SOCBroad
         fields = (
             "uuid",
             "created_at",
@@ -485,9 +485,9 @@ class SocBroadSerializer(serializers.ModelSerializer):
         read_only_fields = ("uuid", "created_at", "updated_at")
 
 
-class SocDetailedSerializer(serializers.ModelSerializer):
+class SOCDetailedSerializer(serializers.ModelSerializer):
     class Meta:
-        model = SocDetailed
+        model = SOCDetailed
         fields = (
             "uuid",
             "soc_broad",
@@ -500,20 +500,20 @@ class SocDetailedSerializer(serializers.ModelSerializer):
         read_only_fields = ("uuid", "created_at", "updated_at")
 
 
-class SocMajorSerializer(serializers.ModelSerializer):
+class SOCMajorSerializer(serializers.ModelSerializer):
     """Used to retrieve soc_major info"""
 
     class Meta:
-        model = SocMajor
+        model = SOCMajor
         fields = ("uuid", "occ_code", "title")
         read_only_fields = ("uuid", "created_at", "updated_at")
 
 
-class SocMinorSerializer(serializers.ModelSerializer):
+class SOCMinorSerializer(serializers.ModelSerializer):
     """Used to retrieve soc_minor info"""
 
     class Meta:
-        model = SocMinor
+        model = SOCMinor
         fields = ("uuid", "soc_major", "occ_code", "title")
         read_only_fields = ("uuid", "created_at", "updated_at")
 

--- a/app/core/api/urls.py
+++ b/app/core/api/urls.py
@@ -22,13 +22,13 @@ from .views import ProjectUrlViewSet
 from .views import ProjectViewSet
 from .views import ReferrerTypeViewSet
 from .views import ReferrerViewSet
-from .views import SdgTargetIndicatorViewSet
-from .views import SdgViewSet
+from .views import SDGTargetIndicatorViewSet
+from .views import SDGViewSet
 from .views import SkillViewSet
-from .views import SocBroadViewSet
-from .views import SocDetailedViewSet
-from .views import SocMajorViewSet
-from .views import SocMinorViewSet
+from .views import SOCBroadViewSet
+from .views import SOCDetailedViewSet
+from .views import SOCMajorViewSet
+from .views import SOCMinorViewSet
 from .views import StackElementTypeViewSet
 from .views import StackElementViewSet
 from .views import UrlStatusTypeViewSet
@@ -66,9 +66,9 @@ router.register(r"permission-types", PermissionTypeViewSet, basename="permission
 router.register(
     r"stack-element-types", StackElementTypeViewSet, basename="stack-element-type"
 )
-router.register(r"sdgs", SdgViewSet, basename="sdg")
+router.register(r"sdgs", SDGViewSet, basename="sdg")
 router.register(
-    r"sdg-target-indicators", SdgTargetIndicatorViewSet, basename="sdg-target-indicator"
+    r"sdg-target-indicators", SDGTargetIndicatorViewSet, basename="sdg-target-indicator"
 )
 router.register(
     r"affiliations",
@@ -80,10 +80,10 @@ router.register(
     r"project-statuses", ProjectProgramAreaStatusTypeViewSet, basename="project-status"
 )
 router.register(r"project-urls", ProjectUrlViewSet, basename="project-url")
-router.register(r"soc-broads", SocBroadViewSet, basename="soc-broad")
-router.register(r"soc-detailed", SocDetailedViewSet, basename="soc-detailed")
-router.register(r"soc-majors", SocMajorViewSet, basename="soc-major")
-router.register(r"soc-minors", SocMinorViewSet, basename="soc-minor")
+router.register(r"soc-broads", SOCBroadViewSet, basename="soc-broad")
+router.register(r"soc-detailed", SOCDetailedViewSet, basename="soc-detailed")
+router.register(r"soc-majors", SOCMajorViewSet, basename="soc-major")
+router.register(r"soc-minors", SOCMinorViewSet, basename="soc-minor")
 router.register(r"url-types", UrlTypeViewSet, basename="url-type")
 router.register(
     r"user-status-types", UserStatusTypeViewSet, basename="user-status-type"

--- a/app/core/api/views.py
+++ b/app/core/api/views.py
@@ -36,12 +36,12 @@ from ..models import ProjectUrl
 from ..models import Referrer
 from ..models import ReferrerType
 from ..models import Sdg
-from ..models import SdgTargetIndicator
+from ..models import SDGTargetIndicator
 from ..models import Skill
-from ..models import SocBroad
-from ..models import SocDetailed
-from ..models import SocMajor
-from ..models import SocMinor
+from ..models import SOCBroad
+from ..models import SOCDetailed
+from ..models import SOCMajor
+from ..models import SOCMinor
 from ..models import StackElement
 from ..models import StackElementType
 from ..models import UrlStatusType
@@ -73,13 +73,13 @@ from .serializers import ProjectStackElementXrefSerializer
 from .serializers import ProjectUrlSerializer
 from .serializers import ReferrerSerializer
 from .serializers import ReferrerTypeSerializer
-from .serializers import SdgSerializer
-from .serializers import SdgTargetIndicatorSerializer
+from .serializers import SDGSerializer
+from .serializers import SDGTargetIndicatorSerializer
 from .serializers import SkillSerializer
-from .serializers import SocBroadSerializer
-from .serializers import SocDetailedSerializer
-from .serializers import SocMajorSerializer
-from .serializers import SocMinorSerializer
+from .serializers import SOCBroadSerializer
+from .serializers import SOCDetailedSerializer
+from .serializers import SOCMajorSerializer
+from .serializers import SOCMinorSerializer
 from .serializers import StackElementSerializer
 from .serializers import StackElementTypeSerializer
 from .serializers import UrlStatusTypeSerializer
@@ -405,10 +405,10 @@ class StackElementTypeViewSet(viewsets.ModelViewSet):
     update=extend_schema(description="Update a recurring event"),
     partial_update=extend_schema(description="Patch a recurring event"),
 )
-class SdgViewSet(viewsets.ModelViewSet):
+class SDGViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
     queryset = Sdg.objects.all()
-    serializer_class = SdgSerializer
+    serializer_class = SDGSerializer
 
 
 @extend_schema_view(
@@ -421,10 +421,10 @@ class SdgViewSet(viewsets.ModelViewSet):
     ),
     destroy=extend_schema(description="Delete an SDG Target Indicator"),
 )
-class SdgTargetIndicatorViewSet(viewsets.ModelViewSet):
+class SDGTargetIndicatorViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
-    queryset = SdgTargetIndicator.objects.all()
-    serializer_class = SdgTargetIndicatorSerializer
+    queryset = SDGTargetIndicator.objects.all()
+    serializer_class = SDGTargetIndicatorSerializer
 
 
 @extend_schema_view(
@@ -505,10 +505,10 @@ class UserPermissionViewSet(viewsets.ReadOnlyModelViewSet):
     update=extend_schema(description="Update a SOC broad occupation"),
     partial_update=extend_schema(description="Patch a SOC broad occupation"),
 )
-class SocBroadViewSet(viewsets.ModelViewSet):
+class SOCBroadViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
-    queryset = SocBroad.objects.select_related("soc_minor").all().order_by("title")
-    serializer_class = SocBroadSerializer
+    queryset = SOCBroad.objects.select_related("soc_minor").all().order_by("title")
+    serializer_class = SOCBroadSerializer
 
 
 @extend_schema_view(
@@ -519,10 +519,10 @@ class SocBroadViewSet(viewsets.ModelViewSet):
     update=extend_schema(description="Update a SOC detailed record"),
     partial_update=extend_schema(description="Patch a SOC detailed record"),
 )
-class SocDetailedViewSet(viewsets.ModelViewSet):
+class SOCDetailedViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
-    queryset = SocDetailed.objects.all()
-    serializer_class = SocDetailedSerializer
+    queryset = SOCDetailed.objects.all()
+    serializer_class = SOCDetailedSerializer
 
 
 @extend_schema_view(
@@ -533,10 +533,10 @@ class SocDetailedViewSet(viewsets.ModelViewSet):
     update=extend_schema(description="Update a soc major"),
     partial_update=extend_schema(description="Patch a soc major"),
 )
-class SocMajorViewSet(viewsets.ModelViewSet):
+class SOCMajorViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
-    queryset = SocMajor.objects.all()
-    serializer_class = SocMajorSerializer
+    queryset = SOCMajor.objects.all()
+    serializer_class = SOCMajorSerializer
 
 
 @extend_schema_view(
@@ -547,10 +547,10 @@ class SocMajorViewSet(viewsets.ModelViewSet):
     update=extend_schema(description="Update a soc minor"),
     partial_update=extend_schema(description="Patch a soc major"),
 )
-class SocMinorViewSet(viewsets.ModelViewSet):
+class SOCMinorViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
-    queryset = SocMinor.objects.all()
-    serializer_class = SocMinorSerializer
+    queryset = SOCMinor.objects.all()
+    serializer_class = SOCMinorSerializer
 
 
 @extend_schema_view(

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -331,7 +331,7 @@ class Location(AbstractBaseModel):
 
 class ModernJobTitle(AbstractBaseModel):
     soc_detailed = models.ForeignKey(
-        "SocDetailed",
+        "SOCDetailed",
         on_delete=models.CASCADE,
         related_name="modern_job_titles",
     )
@@ -488,7 +488,7 @@ class Sdg(AbstractBaseModel):
         return f"{self.name}"
 
 
-class SdgTargetIndicator(AbstractBaseModel):
+class SDGTargetIndicator(AbstractBaseModel):
     """
     Target indicators for each SDG.
     """
@@ -563,13 +563,13 @@ class EventType(AbstractBaseModel):
         return f"{self.name}"
 
 
-class SocBroad(AbstractBaseModel):
+class SOCBroad(AbstractBaseModel):
     """
-    Broad SOC category tied to a SocMinor.
+    Broad SOC category tied to a SOCMinor.
     """
 
     soc_minor = models.ForeignKey(
-        "SocMinor",
+        "SOCMinor",
         on_delete=models.CASCADE,
         related_name="soc_broads",
     )
@@ -580,13 +580,13 @@ class SocBroad(AbstractBaseModel):
         return self.title
 
 
-class SocDetailed(AbstractBaseModel):
+class SOCDetailed(AbstractBaseModel):
     """
     Dictionary of SOC detailed occupations.
     """
 
     soc_broad = models.ForeignKey(
-        "SocBroad",
+        "SOCBroad",
         on_delete=models.CASCADE,
         related_name="soc_detailed",
     )
@@ -599,7 +599,7 @@ class SocDetailed(AbstractBaseModel):
         return f"{self.occ_code} - {self.title}"
 
 
-class SocMajor(AbstractBaseModel):
+class SOCMajor(AbstractBaseModel):
     occ_code = models.CharField(max_length=255)
     title = models.CharField(max_length=255)
 
@@ -607,9 +607,9 @@ class SocMajor(AbstractBaseModel):
         return self.title
 
 
-class SocMinor(AbstractBaseModel):
+class SOCMinor(AbstractBaseModel):
     soc_major = models.ForeignKey(
-        SocMajor, blank=True, null=True, on_delete=models.CASCADE
+        SOCMajor, blank=True, null=True, on_delete=models.CASCADE
     )
     occ_code = models.CharField(max_length=255)
     title = models.CharField(max_length=255)
@@ -869,7 +869,7 @@ class UserEmploymentHistory(AbstractBaseModel):
     )
 
     soc_detailed = models.ForeignKey(
-        "SocDetailed",
+        "SOCDetailed",
         on_delete=models.CASCADE,
         related_name="user_employment_histories",
     )

--- a/app/core/tests/conftest.py
+++ b/app/core/tests/conftest.py
@@ -26,12 +26,12 @@ from ..models import ProjectUrl
 from ..models import Referrer
 from ..models import ReferrerType
 from ..models import Sdg
-from ..models import SdgTargetIndicator
+from ..models import SDGTargetIndicator
 from ..models import Skill
-from ..models import SocBroad
-from ..models import SocDetailed
-from ..models import SocMajor
-from ..models import SocMinor
+from ..models import SOCBroad
+from ..models import SOCDetailed
+from ..models import SOCMajor
+from ..models import SOCMinor
 from ..models import StackElement
 from ..models import StackElementType
 from ..models import UrlStatusType
@@ -290,7 +290,7 @@ def sdg1():
 
 @pytest.fixture
 def sdg_target_indicator(sdg):
-    return SdgTargetIndicator.objects.create(
+    return SDGTargetIndicator.objects.create(
         sdg=sdg,
         code="1.1",
         description_number="Target 1.1",
@@ -362,7 +362,7 @@ def project_status():
 
 @pytest.fixture
 def soc_broad(soc_minor):
-    return SocBroad.objects.create(
+    return SOCBroad.objects.create(
         soc_minor=soc_minor,
         occ_code="15-1252",
         title="Software Developers",
@@ -371,7 +371,7 @@ def soc_broad(soc_minor):
 
 @pytest.fixture
 def soc_detailed(soc_broad):
-    return SocDetailed.objects.create(
+    return SOCDetailed.objects.create(
         soc_broad=soc_broad,
         occ_code="15-1252",
         title="Software Developers",
@@ -381,12 +381,12 @@ def soc_detailed(soc_broad):
 
 @pytest.fixture
 def soc_major():
-    return SocMajor.objects.create(occ_code="22-2222", title="Test Soc Major")
+    return SOCMajor.objects.create(occ_code="22-2222", title="Test Soc Major")
 
 
 @pytest.fixture
 def soc_minor():
-    return SocMinor.objects.create(occ_code="22-2222", title="Test Soc Minor")
+    return SOCMinor.objects.create(occ_code="22-2222", title="Test Soc Minor")
 
 
 @pytest.fixture

--- a/app/core/tests/test_api.py
+++ b/app/core/tests/test_api.py
@@ -12,9 +12,9 @@ from core.models import Organization
 from core.models import ProgramArea
 from core.models import ProjectStackElementXref
 from core.models import ProjectUrl
-from core.models import SdgTargetIndicator
-from core.models import SocBroad
-from core.models import SocDetailed
+from core.models import SDGTargetIndicator
+from core.models import SOCBroad
+from core.models import SOCDetailed
 from core.models import UrlStatusType
 from core.models import UserCheck
 from core.models import UserEmploymentHistory
@@ -538,7 +538,7 @@ def test_create_sdg_target_indicator(auth_client, sdg):
     res = auth_client.post(SDG_TARGET_INDICATOR_URL, payload)
     assert res.status_code == 201
 
-    created = SdgTargetIndicator.objects.get(uuid=res.data["uuid"])
+    created = SDGTargetIndicator.objects.get(uuid=res.data["uuid"])
     assert created.code == payload["code"]
     assert created.description_number == payload["description_number"]
     assert created.sdg == sdg
@@ -576,7 +576,7 @@ def test_delete_sdg_target_indicator(auth_client, sdg_target_indicator):
 
     res = auth_client.delete(url)
     assert res.status_code == 204
-    assert SdgTargetIndicator.objects.count() == 0
+    assert SDGTargetIndicator.objects.count() == 0
 
 
 def test_create_affiliation(auth_client, project, affiliate):
@@ -622,7 +622,7 @@ def test_list_soc_broads(auth_client):
     assert len(res.data) > 0
 
     for item in res.data:
-        soc_broad = SocBroad.objects.get(uuid=item["uuid"])
+        soc_broad = SOCBroad.objects.get(uuid=item["uuid"])
         assert soc_broad.title == item["title"]
         assert soc_broad.soc_minor.pk == item["soc_minor"]
 
@@ -638,7 +638,7 @@ def test_create_soc_broad(auth_client, soc_minor):
 
     assert res.status_code == status.HTTP_201_CREATED
 
-    created = SocBroad.objects.get(uuid=res.data["uuid"])
+    created = SOCBroad.objects.get(uuid=res.data["uuid"])
     assert created.soc_minor == soc_minor
     assert created.occ_code == payload["occ_code"]
     assert created.title == payload["title"]
@@ -650,7 +650,7 @@ def test_list_soc_detailed(auth_client):
     assert res.status_code == status.HTTP_200_OK
     assert len(res.data) > 0
     for item in res.data:
-        soc_detailed = SocDetailed.objects.get(uuid=item["uuid"])
+        soc_detailed = SOCDetailed.objects.get(uuid=item["uuid"])
         assert soc_detailed.occ_code == item["occ_code"]
         assert soc_detailed.soc_broad.pk == item["soc_broad"]
 
@@ -677,7 +677,7 @@ def test_create_soc_detailed(auth_client, soc_broad):
     res = auth_client.post(SOC_DETAILED_URL, payload)
     assert res.status_code == status.HTTP_201_CREATED
 
-    created = SocDetailed.objects.get(uuid=res.data["uuid"])
+    created = SOCDetailed.objects.get(uuid=res.data["uuid"])
     assert created.occ_code == payload["occ_code"]
     assert created.title == payload["title"]
     assert created.soc_broad == soc_broad
@@ -713,10 +713,10 @@ def test_partial_update_soc_detailed(auth_client, soc_detailed):
 def test_delete_soc_detailed(auth_client, soc_detailed):
     url = f"{SOC_DETAILED_URL}{soc_detailed.pk}/"
 
-    detailed_count = SocDetailed.objects.count()
+    detailed_count = SOCDetailed.objects.count()
     res = auth_client.delete(url)
     assert res.status_code == status.HTTP_204_NO_CONTENT
-    assert SocDetailed.objects.count() == detailed_count - 1
+    assert SOCDetailed.objects.count() == detailed_count - 1
 
 
 def test_create_soc_major(auth_client):

--- a/app/core/tests/test_models.py
+++ b/app/core/tests/test_models.py
@@ -17,8 +17,8 @@ from ..models import ProjectStackElementXref
 from ..models import ProjectUrl
 from ..models import ReferrerType
 from ..models import Sdg
-from ..models import SdgTargetIndicator
-from ..models import SocDetailed
+from ..models import SDGTargetIndicator
+from ..models import SOCDetailed
 from ..models import User
 from ..models import UserCheck
 from ..models import UserEmploymentHistory
@@ -180,7 +180,7 @@ def test_sdg(sdg):
 
 
 def test_create_sdg_target_indicator(sdg):
-    indicator = SdgTargetIndicator.objects.create(
+    indicator = SDGTargetIndicator.objects.create(
         sdg=sdg,
         code="1.1",
         description_number="Target 1.1",
@@ -195,7 +195,7 @@ def test_create_sdg_target_indicator(sdg):
 
 
 def test_sdg_deletion_cascades_to_target_indicators(sdg):
-    SdgTargetIndicator.objects.create(
+    SDGTargetIndicator.objects.create(
         sdg=sdg,
         code="1.2",
         description_number="Target 1.2",
@@ -203,17 +203,17 @@ def test_sdg_deletion_cascades_to_target_indicators(sdg):
     )
 
     sdg.delete()
-    assert SdgTargetIndicator.objects.count() == 0
+    assert SDGTargetIndicator.objects.count() == 0
 
 
 def test_sdg_can_have_multiple_indicators(sdg):
-    ind1 = SdgTargetIndicator.objects.create(
+    ind1 = SDGTargetIndicator.objects.create(
         sdg=sdg,
         code="1.1",
         description_number="Target 1.1",
         description_text="First",
     )
-    ind2 = SdgTargetIndicator.objects.create(
+    ind2 = SDGTargetIndicator.objects.create(
         sdg=sdg,
         code="1.2",
         description_number="Target 1.2",
@@ -228,7 +228,7 @@ def test_sdg_can_have_multiple_indicators(sdg):
 
 
 def test_indicator_str_method(sdg):
-    indicator = SdgTargetIndicator.objects.create(
+    indicator = SDGTargetIndicator.objects.create(
         sdg=sdg,
         code="1.3",
         description_number="Target 1.3",
@@ -324,7 +324,7 @@ def test_soc_broad_relationships(soc_broad, soc_minor):
 
 
 def test_create_soc_detailed(soc_broad):
-    soc = SocDetailed.objects.create(
+    soc = SOCDetailed.objects.create(
         soc_broad=soc_broad,
         occ_code="11-1111",
         title="Test SOC Detailed",
@@ -339,7 +339,7 @@ def test_create_soc_detailed(soc_broad):
 
 
 def test_soc_detailed_str_method(soc_broad):
-    soc = SocDetailed.objects.create(
+    soc = SOCDetailed.objects.create(
         soc_broad=soc_broad,
         occ_code="22-2222",
         title="Title",
@@ -350,13 +350,13 @@ def test_soc_detailed_str_method(soc_broad):
 
 
 def test_soc_broad_has_multiple_soc_detailed(soc_broad):
-    d1 = SocDetailed.objects.create(
+    d1 = SOCDetailed.objects.create(
         soc_broad=soc_broad,
         occ_code="15-1111",
         title="Title 1",
         description="Desc 1",
     )
-    d2 = SocDetailed.objects.create(
+    d2 = SOCDetailed.objects.create(
         soc_broad=soc_broad,
         occ_code="15-2222",
         title="Title 2",
@@ -371,9 +371,9 @@ def test_soc_broad_has_multiple_soc_detailed(soc_broad):
 
 
 def test_soc_broad_deletion_cascades_to_soc_detailed(soc_broad):
-    initial_count = SocDetailed.objects.count()
+    initial_count = SOCDetailed.objects.count()
 
-    SocDetailed.objects.create(
+    SOCDetailed.objects.create(
         soc_broad=soc_broad,
         occ_code="15-3333",
         title="Cascade Test",
@@ -381,7 +381,7 @@ def test_soc_broad_deletion_cascades_to_soc_detailed(soc_broad):
     )
 
     soc_broad.delete()
-    assert SocDetailed.objects.count() == initial_count
+    assert SOCDetailed.objects.count() == initial_count
 
 
 def test_soc_major(soc_major):

--- a/app/data/migrations/0006_socmajor_seed.py
+++ b/app/data/migrations/0006_socmajor_seed.py
@@ -1,6 +1,6 @@
 from django.db import migrations
 
-from core.models import SocMajor
+from core.models import SOCMajor
 
 
 def forward(__code__, __reverse_code__):
@@ -17,11 +17,11 @@ def forward(__code__, __reverse_code__):
         (10, "29-0000", "Healthcare Practitioners and Technical Occupations"),
     ]
     for uuid, occ_code, title in items:
-        SocMajor.objects.create(uuid=uuid, occ_code=occ_code, title=title)
+        SOCMajor.objects.create(uuid=uuid, occ_code=occ_code, title=title)
 
 
 def reverse(__code__, __reverse_code__):
-    SocMajor.objects.all().delete()
+    SOCMajor.objects.all().delete()
 
 
 class Migration(migrations.Migration):

--- a/app/data/migrations/0013_socmajor_seed.py
+++ b/app/data/migrations/0013_socmajor_seed.py
@@ -1,6 +1,6 @@
 from django.db import migrations
 
-from core.models import SocMajor
+from core.models import SOCMajor
 
 
 def forward(__code__, __reverse_code__):
@@ -19,11 +19,11 @@ def forward(__code__, __reverse_code__):
         (22, "53-0000", "Transportation and Material Moving Occupations"),
     ]
     for uuid, occ_code, title in items:
-        SocMajor.objects.create(uuid=uuid, occ_code=occ_code, title=title)
+        SOCMajor.objects.create(uuid=uuid, occ_code=occ_code, title=title)
 
 
 def reverse(__code__, __reverse_code__):
-    SocMajor.objects.all().delete()
+    SOCMajor.objects.all().delete()
 
 
 class Migration(migrations.Migration):

--- a/app/data/migrations/0014_socminor_seed.py
+++ b/app/data/migrations/0014_socminor_seed.py
@@ -1,7 +1,7 @@
 from django.db import migrations
 
-from core.models import SocMinor
-from core.models import SocMajor
+from core.models import SOCMinor
+from core.models import SOCMajor
 
 
 def forward(__code__, __reverse_code__):
@@ -180,16 +180,16 @@ def forward(__code__, __reverse_code__):
         (92, "22", "53-7000", "Material Moving Workers"),
     ]
     for uuid, soc_major_id, occ_code, title in items:
-        SocMinor.objects.create(
+        SOCMinor.objects.create(
             uuid=uuid,
-            soc_major=SocMajor.objects.get(uuid=int(soc_major_id)),
+            soc_major=SOCMajor.objects.get(uuid=int(soc_major_id)),
             occ_code=occ_code,
             title=title,
         )
 
 
 def reverse(__code__, __reverse_code__):
-    SocMinor.objects.all().delete()
+    SOCMinor.objects.all().delete()
 
 
 class Migration(migrations.Migration):

--- a/app/data/migrations/0015_socbroad_seed.py
+++ b/app/data/migrations/0015_socbroad_seed.py
@@ -1,7 +1,7 @@
 from django.db import migrations
 
-from core.models import SocBroad
-from core.models import SocMinor
+from core.models import SOCBroad
+from core.models import SOCMinor
 
 
 def forward(__code__, __reverse_code__):
@@ -773,16 +773,16 @@ def forward(__code__, __reverse_code__):
         (425, "92", "53-7190", "Miscellaneous Material Moving Workers"),
     ]
     for uuid, soc_minor_id, occ_code, title in items:
-        SocBroad.objects.create(
+        SOCBroad.objects.create(
             uuid=uuid,
-            soc_minor=SocMinor.objects.get(uuid=int(soc_minor_id)),
+            soc_minor=SOCMinor.objects.get(uuid=int(soc_minor_id)),
             occ_code=occ_code,
             title=title,
         )
 
 
 def reverse(__code__, __reverse_code__):
-    SocBroad.objects.all().delete()
+    SOCBroad.objects.all().delete()
 
 
 class Migration(migrations.Migration):

--- a/app/data/migrations/0016_socdetailed_seed.py
+++ b/app/data/migrations/0016_socdetailed_seed.py
@@ -1,7 +1,7 @@
 from django.db import migrations
 
-from core.models import SocDetailed
-from core.models import SocBroad
+from core.models import SOCDetailed
+from core.models import SOCBroad
 
 
 def forward(__code__, __reverse_code__):
@@ -5490,9 +5490,9 @@ def forward(__code__, __reverse_code__):
     ]
 
     for uuid, soc_broad_id, occ_code, title, description in items:
-        SocDetailed.objects.create(
+        SOCDetailed.objects.create(
             uuid=uuid,
-            soc_broad=SocBroad.objects.get(uuid=int(soc_broad_id)),
+            soc_broad=SOCBroad.objects.get(uuid=int(soc_broad_id)),
             occ_code=occ_code,
             title=title,
             description=description,
@@ -5500,7 +5500,7 @@ def forward(__code__, __reverse_code__):
 
 
 def reverse(__code__, __reverse_code__):
-    SocDetailed.objects.all().delete()
+    SOCDetailed.objects.all().delete()
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
…ws and serializers to follow standard casing conventions

Fixes #617 
### What changes did you make?

- renamed Soc* and SdgTargetIndicator classes to SOC* and SDGTargetIndicator
- did the same for related views and initializers
- updated tests and data migrations

### Why did you make the changes (we will use this info to test)?

- follow PEP naming conventions

### Screenshots of Proposed Changes Of The Website (if any, please do not screen shot code changes)

<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->

<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>

<details>
<summary>Visuals after changes are applied</summary>

![image](Paste_Your_Image_Link_Here_After_Attaching_Files)

</details>
